### PR TITLE
v3.3.0

### DIFF
--- a/ProceduralDungeon.uplugin
+++ b/ProceduralDungeon.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 30202,
-	"VersionName": "3.2.2",
+	"Version": 30300,
+	"VersionName": "3.3.0",
 	"FriendlyName": "Procedural Dungeon",
 	"Description": "Create procedural dungeons like \"The Binding of Isaac\" or \"Rogue Legacy\" but in 3D.\r\nYou can define your own generation rules.",
 	"Category": "Procedural",

--- a/Source/ProceduralDungeon/Private/Components/StaticRoomVisibilityComponent.cpp
+++ b/Source/ProceduralDungeon/Private/Components/StaticRoomVisibilityComponent.cpp
@@ -1,0 +1,158 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Benoit Pelletier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "Components/StaticRoomVisibilityComponent.h"
+#include "ProceduralDungeonUtils.h"
+#include "ProceduralDungeonLog.h"
+#include "RoomLevel.h"
+
+UStaticRoomVisibilityComponent::UStaticRoomVisibilityComponent()
+{
+	PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UStaticRoomVisibilityComponent::BeginPlay()
+{
+	Super::BeginPlay();
+	UpdateVisibility();
+	RegisterVisibilityDelegate(GetOwnerRoomLevel(), true);
+}
+
+void UStaticRoomVisibilityComponent::EndPlay(EEndPlayReason::Type Reason)
+{
+	Super::EndPlay(Reason);
+	RegisterVisibilityDelegate(GetOwnerRoomLevel(), false);
+}
+
+bool UStaticRoomVisibilityComponent::IsVisible()
+{
+	return Dungeon::OccludeDynamicActors() ? VisibilityEnablers.Num() > 0: true;
+}
+
+void UStaticRoomVisibilityComponent::SetVisible(UObject* Owner, bool Visible)
+{
+	const bool bOldVisible = IsVisible();
+	if (Visible)
+		VisibilityEnablers.Add(Owner);
+	else
+		VisibilityEnablers.Remove(Owner);
+
+	const bool bNewVisible = IsVisible();
+	DungeonLog_InfoSilent("Visibility of '%s' Changed: %d (before: %d)", *GetNameSafe(GetOwner()), bNewVisible, bOldVisible);
+	if (bOldVisible == bNewVisible)
+		return;
+
+	UpdateVisibility();
+	DungeonLog_InfoSilent("Dispatch Room Visibility Event of '%s'", *GetNameSafe(GetOwner()));
+	OnRoomVisibilityChanged.Broadcast(GetOwner(), bNewVisible);
+}
+
+void UStaticRoomVisibilityComponent::ResetVisible(UObject* Owner)
+{
+	SetVisible(Owner, false);
+}
+
+void UStaticRoomVisibilityComponent::SetVisibilityMode(EVisibilityMode Mode)
+{
+	VisibilityMode = Mode;
+	UpdateVisibility();
+}
+
+ARoomLevel* UStaticRoomVisibilityComponent::GetOwnerRoomLevel() const
+{
+	ULevel* Level = GetOwner()->GetLevel();
+	if (!IsValid(Level))
+		return nullptr;
+
+	return Cast<ARoomLevel>(Level->GetLevelScriptActor());
+}
+
+void UStaticRoomVisibilityComponent::UpdateVisibility()
+{
+	CleanEnablers();
+
+	AActor* Actor = GetOwner();
+	if (!IsValid(Actor))
+		return;
+
+	// Can't use Actor->SetActorHiddenInGame() because it is replicated over network.
+	// So instead we use the Root->SetVisibility() and propagate it to its children.
+	// TODO: try to use something better than that (non-replicated but actor-wide).
+	USceneComponent* Root = Actor->GetRootComponent();
+	if (!IsValid(Root))
+		return;
+
+	switch (VisibilityMode)
+	{
+	case EVisibilityMode::Default:
+		Root->SetVisibility(IsVisible(), true);
+		break;
+	case EVisibilityMode::ForceHidden:
+		Root->SetVisibility(false, true);
+		break;
+	case EVisibilityMode::ForceVisible:
+		Root->SetVisibility(true, true);
+		break;
+	case EVisibilityMode::Custom:
+		// The user handles the visibility
+		break;
+	default:
+		checkNoEntry();
+		break;
+	}
+}
+
+void UStaticRoomVisibilityComponent::RegisterVisibilityDelegate(ARoomLevel* RoomLevel, bool Register)
+{
+	if (!IsValid(RoomLevel))
+		return;
+
+	if (Register)
+		RoomLevel->VisibilityChangedEvent.AddDynamic(this, &UStaticRoomVisibilityComponent::RoomVisibilityChanged);
+	else
+		RoomLevel->VisibilityChangedEvent.RemoveDynamic(this, &UStaticRoomVisibilityComponent::RoomVisibilityChanged);
+
+	SetVisible(RoomLevel, RoomLevel->IsVisible());
+}
+
+void UStaticRoomVisibilityComponent::RoomVisibilityChanged(ARoomLevel* RoomLevel, bool IsVisible)
+{
+	DungeonLog_InfoSilent("[%s] Room '%s' Visibility Changed: %d", *GetNameSafe(GetOwner()), *GetNameSafe(RoomLevel), IsVisible);
+	SetVisible(RoomLevel, IsVisible);
+}
+
+void UStaticRoomVisibilityComponent::CleanEnablers()
+{
+	TSet<TWeakObjectPtr<UObject>> ObjPtrToRemove;
+	for (TWeakObjectPtr<UObject> ObjPtr : VisibilityEnablers)
+	{
+		if (!ObjPtr.IsValid())
+			ObjPtrToRemove.Add(ObjPtr);
+	}
+
+	for (TWeakObjectPtr<UObject> ObjPtr : ObjPtrToRemove)
+	{
+		VisibilityEnablers.Remove(ObjPtr);
+	}
+}

--- a/Source/ProceduralDungeon/Private/Door.cpp
+++ b/Source/ProceduralDungeon/Private/Door.cpp
@@ -39,7 +39,8 @@ ADoor::ADoor()
 	bAlwaysRelevant = true; // prevent the doors from despawning on clients when server's player is too far
 	NetDormancy = ENetDormancy::DORM_DormantAll;
 
-	RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("SceneComponent"));
+	DefaultSceneComponent = CreateDefaultSubobject<USceneComponent>(TEXT("SceneComponent"));
+	RootComponent = DefaultSceneComponent;
 }
 
 void ADoor::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const

--- a/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
@@ -683,6 +683,16 @@ URoomData* ADungeonGenerator::GetRandomRoomData(TArray<URoomData*> RoomDataArray
 	return RoomDataArray[n];
 }
 
+URoomData* ADungeonGenerator::GetRandomRoomDataWeighted(const TMap<URoomData*, int>& RoomDataWeightedMap)
+{
+	if (RoomDataWeightedMap.Num() <= 0)
+		return nullptr;
+
+	int Total = Dungeon::GetTotalWeight(RoomDataWeightedMap);
+	const int Chosen = Random.RandRange(0, Total - 1);
+	return Dungeon::GetWeightedAt(RoomDataWeightedMap, Chosen);
+}
+
 void ADungeonGenerator::GetCompatibleRoomData(bool& bSuccess, TArray<URoomData*>& CompatibleRooms, const TArray<URoomData*>& RoomDataArray, const FDoorDef& DoorData)
 {
 	for (URoomData* RoomData : RoomDataArray)

--- a/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
@@ -81,7 +81,6 @@ bool ADungeonGenerator::ReplicateSubobjects(UActorChannel* Channel, FOutBunch* B
 	return bWroteSomething;
 }
 
-// Called when the game starts or when spawned
 void ADungeonGenerator::BeginPlay()
 {
 	Super::BeginPlay();
@@ -95,7 +94,6 @@ void ADungeonGenerator::EndPlay(EEndPlayReason::Type EndPlayReason)
 		UnloadAllRooms();
 }
 
-// Called every frame
 void ADungeonGenerator::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);

--- a/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
@@ -167,6 +167,7 @@ void ADungeonGenerator::CreateDungeon()
 		URoom* root = NewObject<URoom>(this);
 		root->Init(def, this, 0);
 		Graph->AddRoom(root);
+		OnRoomAdded(root->GetRoomData());
 
 		// Build the list of rooms
 		TQueueOrStack<URoom*> roomStack(listMode);

--- a/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
@@ -108,7 +108,6 @@ void ADungeonGenerator::Generate()
 	if (HasAuthority())
 	{
 		Graph->RequestGeneration();
-		// TODO: wake up here for dormancy
 	}
 }
 
@@ -118,7 +117,6 @@ void ADungeonGenerator::Unload()
 	if (HasAuthority())
 	{
 		Graph->RequestUnload();
-		// TODO: wake up here for dormancy
 	}
 }
 
@@ -138,8 +136,6 @@ void ADungeonGenerator::CreateDungeon()
 
 		// Reset generation data
 		OnGenerationInit();
-
-		// Create the first room
 		Graph->Clear();
 
 		// Create the list with the correct mode (depth or breadth)
@@ -164,6 +160,7 @@ void ADungeonGenerator::CreateDungeon()
 			continue;
 		}
 
+		// Create the first room
 		URoom* root = NewObject<URoom>(this);
 		root->Init(def, this, 0);
 		Graph->AddRoom(root);
@@ -235,6 +232,7 @@ void ADungeonGenerator::InstantiateRoom(URoom* Room)
 				FQuat InstanceDoorRot = GetDungeonRotation() * FRotator(0, 90 * (int8)DoorRot + Flipped * 180, 0).Quaternion();
 				FActorSpawnParameters SpawnParams;
 				SpawnParams.Owner = this;
+				SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 				ADoor* Door = GetWorld()->SpawnActor<ADoor>(DoorClass, InstanceDoorPos, InstanceDoorRot.Rotator(), SpawnParams);
 
 				if (IsValid(Door))

--- a/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
@@ -398,7 +398,11 @@ void ADungeonGenerator::UnloadAllRooms()
 
 void ADungeonGenerator::UpdateRoomVisibility()
 {
-	APawn* Player = UGameplayStatics::GetPlayerController(GetWorld(), 0)->GetPawnOrSpectator();
+	APlayerController* Controller = UGameplayStatics::GetPlayerController(GetWorld(), 0);
+	if (!IsValid(Controller))
+		return;
+
+	APawn* Player = Controller->GetPawnOrSpectator();
 	if (!IsValid(Player))
 		return;
 

--- a/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGenerator.cpp
@@ -129,7 +129,7 @@ void ADungeonGenerator::CreateDungeon()
 	if (!HasAuthority())
 		return;
 
-	int TriesLeft = MaxTry;
+	int TriesLeft = Dungeon::MaxGenerationTryBeforeGivingUp();
 	bool ValidDungeon = false;
 
 	// generate level until IsValidDungeon return true
@@ -197,7 +197,7 @@ void ADungeonGenerator::CreateDungeon()
 
 	if (!ValidDungeon)
 	{
-		DungeonLog_Error("Generated dungeon is not valid after %d tries. Make sure your IsValidDungeon function is correct.", MaxTry);
+		DungeonLog_Error("Generated dungeon is not valid after %d tries. Make sure your IsValidDungeon function is correct.", Dungeon::MaxGenerationTryBeforeGivingUp());
 		Graph->Clear();
 		OnGenerationFailed();
 		return;
@@ -287,7 +287,7 @@ bool ADungeonGenerator::AddNewRooms(URoom& ParentRoom, TArray<URoom*>& AddedRoom
 		const FIntVector newRoomPos = doorDef.Position + ToIntVector(doorDef.Direction);
 		const EDoorDirection newRoomDoorDir = ~doorDef.Direction;
 
-		int nbTries = MaxRoomTry;
+		int nbTries = Dungeon::MaxRoomPlacementTryBeforeGivingUp();
 		URoom* newRoom = nullptr;
 		// Try to place a new room
 		do

--- a/Source/ProceduralDungeon/Private/DungeonGraph.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGraph.cpp
@@ -409,34 +409,37 @@ void UDungeonGraph::SynchronizeRooms()
 	CurrentState = EDungeonGraphState::None;
 }
 
-bool UDungeonGraph::AreRoomsLoaded() const
+bool UDungeonGraph::AreRoomsLoaded(int32& NbRoomLoaded) const
 {
+	NbRoomLoaded = 0;
 	for (URoom* Room : Rooms)
 	{
-		if (!Room->IsInstanceLoaded())
-			return false;
+		if (Room->IsInstanceLoaded())
+			NbRoomLoaded++;
 	}
-	return true;
+	return NbRoomLoaded >= Rooms.Num();
 }
 
-bool UDungeonGraph::AreRoomsUnloaded() const
+bool UDungeonGraph::AreRoomsUnloaded(int32& NbRoomUnloaded) const
 {
+	NbRoomUnloaded = 0;
 	for (URoom* Room : Rooms)
 	{
-		if (IsValid(Room) && !Room->IsInstanceUnloaded())
-			return false;
+		if (!IsValid(Room) || Room->IsInstanceUnloaded())
+			NbRoomUnloaded++;
 	}
-	return true;
+	return NbRoomUnloaded >= Rooms.Num();
 }
 
-bool UDungeonGraph::AreRoomsInitialized() const
+bool UDungeonGraph::AreRoomsInitialized(int32& NbRoomInitialized) const
 {
+	NbRoomInitialized = 0;
 	for (URoom* Room : Rooms)
 	{
-		if (!Room->IsInstanceInitialized())
-			return false;
+		if (Room->IsInstanceInitialized())
+			NbRoomInitialized++;
 	}
-	return true;
+	return NbRoomInitialized >= Rooms.Num();
 }
 
 void UDungeonGraph::RequestGeneration()

--- a/Source/ProceduralDungeon/Private/DungeonGraph.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGraph.cpp
@@ -208,6 +208,13 @@ URoom* UDungeonGraph::GetRoomByIndex(int64 Index) const
 
 void UDungeonGraph::Clear()
 {
+	for (URoom* Room : Rooms)
+	{
+		check(IsValid(Room));
+		const URoomData* Data = Room->GetRoomData();
+		check(IsValid(Data));
+		Data->CleanupRoom(Room, this);
+	}
 	Rooms.Empty();
 }
 

--- a/Source/ProceduralDungeon/Private/ProceduralDungeonSettings.cpp
+++ b/Source/ProceduralDungeon/Private/ProceduralDungeonSettings.cpp
@@ -33,6 +33,8 @@ UProceduralDungeonSettings::UProceduralDungeonSettings(const FObjectInitializer&
 	DoorSize = FVector(40, 640, 400);
 	DoorOffset = 0.0f;
 	CanLoop = true;
+	MaxGenerationTry = 500;
+	MaxRoomPlacementTry = 10;
 
 	// Occlusion settings
 	OcclusionCulling = true;

--- a/Source/ProceduralDungeon/Private/ProceduralDungeonUtils.cpp
+++ b/Source/ProceduralDungeon/Private/ProceduralDungeonUtils.cpp
@@ -157,6 +157,18 @@ ECollisionChannel Dungeon::RoomObjectType()
 	return Settings->RoomObjectType;
 }
 
+uint32 Dungeon::MaxGenerationTryBeforeGivingUp()
+{
+	const UProceduralDungeonSettings* Settings = GetDefault<UProceduralDungeonSettings>();
+	return Settings->MaxGenerationTry;
+}
+
+uint32 Dungeon::MaxRoomPlacementTryBeforeGivingUp()
+{
+	const UProceduralDungeonSettings* Settings = GetDefault<UProceduralDungeonSettings>();
+	return Settings->MaxRoomPlacementTry;
+}
+
 void Dungeon::EnableOcclusionCulling(bool Enable)
 {
 	UProceduralDungeonSettings* Settings = GetMutableDefault<UProceduralDungeonSettings>();

--- a/Source/ProceduralDungeon/Private/RoomData.cpp
+++ b/Source/ProceduralDungeon/Private/RoomData.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2021 Benoit Pelletier
+ * Copyright (c) 2019-2024 Benoit Pelletier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -68,6 +68,23 @@ FIntVector URoomData::GetSize() const
 FBoxMinAndMax URoomData::GetIntBounds() const
 {
 	return FBoxMinAndMax(FirstPoint, SecondPoint);
+}
+
+bool URoomData::IsRoomInBounds(const FBoxMinAndMax& Bounds, int DoorIndex, const FDoorDef& DoorDungeonPos) const
+{
+	const FIntVector BoundSize = Bounds.GetSize();
+	if (BoundSize.X == 0 || BoundSize.Y == 0 || BoundSize.Z == 0)
+		return false;
+
+	if (DoorIndex < 0 || DoorIndex >= Doors.Num())
+		return false;
+
+	const FDoorDef& Door = Doors[DoorIndex];
+	FBoxMinAndMax RoomBounds = GetIntBounds();
+	RoomBounds -= Door.Position;
+	RoomBounds.Rotate(DoorDungeonPos.Direction - Door.Direction);
+	RoomBounds += DoorDungeonPos.Position;
+	return Bounds.IsInside(RoomBounds);
 }
 
 #if !(UE_BUILD_SHIPPING) || WITH_EDITOR

--- a/Source/ProceduralDungeon/Private/RoomData.cpp
+++ b/Source/ProceduralDungeon/Private/RoomData.cpp
@@ -52,6 +52,10 @@ void URoomData::InitializeRoom_Implementation(URoom* Room, UDungeonGraph* Dungeo
 {
 }
 
+void URoomData::CleanupRoom_Implementation(URoom* Room, UDungeonGraph* Dungeon) const
+{
+}
+
 FBoxCenterAndExtent URoomData::GetBounds(FTransform Transform) const
 {
 	FBoxCenterAndExtent Bounds = GetIntBounds().ToCenterAndExtent();

--- a/Source/ProceduralDungeon/Private/RoomData.cpp
+++ b/Source/ProceduralDungeon/Private/RoomData.cpp
@@ -104,6 +104,17 @@ bool URoomData::IsDoorValid(int DoorIndex) const
 	}
 }
 
+bool URoomData::IsDoorDuplicate(int DoorIndex) const
+{
+	check(DoorIndex >= 0 && DoorIndex < Doors.Num());
+	for (int i = 0; i < Doors.Num(); ++i)
+	{
+		if (DoorIndex != i && Doors[i] == Doors[DoorIndex])
+			return true;
+	}
+	return false;
+}
+
 #endif // !(UE_BUILD_SHIPPING) || WITH_EDITOR
 
 #if WITH_EDITOR
@@ -157,13 +168,10 @@ EDataValidationResult URoomData::IsDataValid(FDataValidationContext& Context) co
 			}
 
 			// Check if there are no duplicated doors
-			for (int k = i + 1; k < Doors.Num(); ++k)
+			if (IsDoorDuplicate(i))
 			{
-				if (Doors[i] == Doors[k])
-				{
-					VALIDATION_LOG_ERROR(FText::FromString(FString::Printf(TEXT("Room data \"%s\" has duplicated doors: %s."), *GetName(), *Doors[i].ToString())));
-					Result = EDataValidationResult::Invalid;
-				}
+				VALIDATION_LOG_ERROR(FText::FromString(FString::Printf(TEXT("Room data \"%s\" has duplicated doors: %s."), *GetName(), *Doors[i].ToString())));
+				Result = EDataValidationResult::Invalid;
 			}
 		}
 	}

--- a/Source/ProceduralDungeon/Private/RoomLevel.cpp
+++ b/Source/ProceduralDungeon/Private/RoomLevel.cpp
@@ -166,7 +166,7 @@ void ARoomLevel::Tick(float DeltaTime)
 		for (int i = 0; i < Data->GetNbDoor(); i++)
 		{
 			const bool bIsConnected = !bIsRoomValid || (bIsRoomDataValid && Room->IsConnected(i));
-			const bool bIsDoorValid = Data->IsDoorValid(i);
+			const bool bIsDoorValid = Data->IsDoorValid(i) && !Data->IsDoorDuplicate(i);
 			FDoorDef::DrawDebug(World, bIsDoorValid ? FColor::Blue : FColor::Orange, Data->Doors[i], RoomTransform * DungeonTransform, true, bIsConnected);
 		}
 	}

--- a/Source/ProceduralDungeon/Private/RoomLevel.cpp
+++ b/Source/ProceduralDungeon/Private/RoomLevel.cpp
@@ -247,6 +247,11 @@ void ARoomLevel::SetActorsVisible(bool Visible)
 			if (Actor->GetIsReplicated())
 				continue;
 
+			// Discard explicitly ignored actors.
+			// They can have a (Static) Room Visibility Component attached to have a custom occlusion management.
+			if (Actor->ActorHasTag(FName("Ignore Room Culling")))
+				continue;
+
 			Actor->SetActorHiddenInGame(!Visible);
 		}
 	}

--- a/Source/ProceduralDungeon/Private/RoomVisibilityComponent.cpp
+++ b/Source/ProceduralDungeon/Private/RoomVisibilityComponent.cpp
@@ -28,121 +28,18 @@
 #include "RoomLevel.h"
 
 URoomVisibilityComponent::URoomVisibilityComponent()
-	: VisibilityMode(EVisibilityMode::Default)
+	: Super()
 {
-	PrimaryComponentTick.bCanEverTick = false;
-}
-
-void URoomVisibilityComponent::BeginPlay()
-{
-	Super::BeginPlay();
-	UpdateVisibility();
 }
 
 void URoomVisibilityComponent::OnRoomEnter_Implementation(ARoomLevel* RoomLevel)
 {
 	DungeonLog_InfoSilent("Visibility Component '%s' Enters Room: %s", *GetNameSafe(GetOwner()), *GetNameSafe(RoomLevel));
-	if (!IsValid(RoomLevel))
-		return;
-
-	SetVisible(RoomLevel, RoomLevel->IsVisible());
-	RoomLevel->VisibilityChangedEvent.AddDynamic(this, &URoomVisibilityComponent::RoomVisibilityChanged);
+	RegisterVisibilityDelegate(RoomLevel, true);
 }
 
 void URoomVisibilityComponent::OnRoomExit_Implementation(ARoomLevel* RoomLevel)
 {
 	DungeonLog_InfoSilent("Visibility Component '%s' Exits Room: %s", *GetNameSafe(GetOwner()), *GetNameSafe(RoomLevel));
-	if (!IsValid(RoomLevel))
-		return;
-
-	RoomLevel->VisibilityChangedEvent.RemoveDynamic(this, &URoomVisibilityComponent::RoomVisibilityChanged);
-	SetVisible(RoomLevel, false);
-}
-
-bool URoomVisibilityComponent::IsVisible()
-{
-	return Dungeon::OccludeDynamicActors() ? VisibilityEnablers.Num() > 0: true;
-}
-
-void URoomVisibilityComponent::SetVisible(UObject* Owner, bool Visible)
-{
-	const bool bOldVisible = IsVisible();
-	if (Visible)
-		VisibilityEnablers.Add(Owner);
-	else
-		VisibilityEnablers.Remove(Owner);
-
-	const bool bNewVisible = IsVisible();
-	DungeonLog_InfoSilent("Visibility of '%s' Changed: %d (before: %d)", *GetNameSafe(GetOwner()), bNewVisible, bOldVisible);
-	if (bOldVisible != bNewVisible)
-	{
-		UpdateVisibility();
-		DungeonLog_InfoSilent("Dispatch Room Visibility Event of '%s'", *GetNameSafe(GetOwner()));
-		OnRoomVisibilityChanged.Broadcast(GetOwner(), bNewVisible);
-	}
-}
-
-void URoomVisibilityComponent::ResetVisible(UObject* Owner)
-{
-	SetVisible(Owner, false);
-}
-
-void URoomVisibilityComponent::SetVisibilityMode(EVisibilityMode Mode)
-{
-	VisibilityMode = Mode;
-	UpdateVisibility();
-}
-
-void URoomVisibilityComponent::UpdateVisibility()
-{
-	CleanEnablers();
-
-	AActor* Actor = GetOwner();
-	if (IsValid(Actor))
-	{
-		// Can't use Actor->SetActorHiddenInGame() because it is replicated over network.
-		USceneComponent* Root = Actor->GetRootComponent();
-		if (IsValid(Root))
-		{
-			switch (VisibilityMode)
-			{
-			case EVisibilityMode::Default:
-				Root->SetVisibility(IsVisible(), true);
-				break;
-			case EVisibilityMode::ForceHidden:
-				Root->SetVisibility(false, true);
-				break;
-			case EVisibilityMode::ForceVisible:
-				Root->SetVisibility(true, true);
-				break;
-			case EVisibilityMode::Custom:
-				// The user handles the visibility
-				break;
-			default:
-				checkNoEntry();
-				break;
-			}
-		}
-	}
-}
-
-void URoomVisibilityComponent::RoomVisibilityChanged(ARoomLevel* RoomLevel, bool IsVisible)
-{
-	DungeonLog_InfoSilent("[%s] Room '%s' Visibility Changed: %d", *GetNameSafe(GetOwner()), *GetNameSafe(RoomLevel), IsVisible);
-	SetVisible(RoomLevel, IsVisible);
-}
-
-void URoomVisibilityComponent::CleanEnablers()
-{
-	TSet<TWeakObjectPtr<UObject>> ObjPtrToRemove;
-	for (TWeakObjectPtr<UObject> ObjPtr : VisibilityEnablers)
-	{
-		if (!ObjPtr.IsValid())
-			ObjPtrToRemove.Add(ObjPtr);
-	}
-
-	for (TWeakObjectPtr<UObject> ObjPtr : ObjPtrToRemove)
-	{
-		VisibilityEnablers.Remove(ObjPtr);
-	}
+	RegisterVisibilityDelegate(RoomLevel, false);
 }

--- a/Source/ProceduralDungeon/Private/Tests/BoxMinAndMaxTests.cpp
+++ b/Source/ProceduralDungeon/Private/Tests/BoxMinAndMaxTests.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Benoit Pelletier
+ * Copyright (c) 2023-2024 Benoit Pelletier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -128,6 +128,123 @@ bool FBoxMinAndMaxTest::RunTest(const FString& Parameters)
 		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), S).Max == (2,1,1)"), RotBox1S.Max, FIntVector(2, 1, 1));
 		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), W).Min == (0,-2,-1)"), RotBox1W.Min, FIntVector(0, -2, -1));
 		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), W).Max == (1,2,1)"), RotBox1W.Max, FIntVector(1, 2, 1));
+	}
+
+	// IsInside(FBoxMinAndMax) Test
+	{
+		FBoxMinAndMax Bounds(FIntVector(-4, -5, -6), FIntVector(7, 8, 9));
+		FBoxMinAndMax Box(FIntVector(-1, -1, -1), FIntVector(1, 2, 3));
+
+		// Completely inside, no coincident face
+		TestTrue(*FString::Printf(TEXT("Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+
+		// Positive X
+		Box += FIntVector(6, 0, 0); // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[X+,A] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(1, 0, 0); // Intersecting
+		TestFalse(*FString::Printf(TEXT("[X+,B] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(1, 0, 0); // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[X+,C] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+
+		// Reset
+		Box = FBoxMinAndMax(FIntVector(-1, -1, -1), FIntVector(1, 2, 3));
+
+		// Positive Y
+		Box += FIntVector(0, 6, 0); // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[Y+,A] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(0, 1, 0); // Intersecting
+		TestFalse(*FString::Printf(TEXT("[Y+,B] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(0, 1, 0); // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[Y+,C] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+
+		// Reset
+		Box = FBoxMinAndMax(FIntVector(-1, -1, -1), FIntVector(1, 2, 3));
+
+		// Positive Z
+		Box += FIntVector(0, 0, 6); // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[Z+,A] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(0, 0, 1); // Intersecting
+		TestFalse(*FString::Printf(TEXT("[Z+,B] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(0, 0, 1); // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[Z+,C] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+
+		// Reset
+		Box = FBoxMinAndMax(FIntVector(-1, -1, -1), FIntVector(1, 2, 3));
+
+		// Negative X
+		Box += FIntVector(-3, 0, 0); // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[X-,A] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(-1, 0, 0); // Intersecting
+		TestFalse(*FString::Printf(TEXT("[X-,B] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(-1, 0, 0); // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[X-,C] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+
+		// Reset
+		Box = FBoxMinAndMax(FIntVector(-1, -1, -1), FIntVector(1, 2, 3));
+
+		// Negative Y
+		Box += FIntVector(0, -4, 0); // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[Y-,A] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(0, -2, 0); // Intersecting
+		TestFalse(*FString::Printf(TEXT("[Y-,B] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(0, -1, 0); // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[Y-,C] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+
+		// Reset
+		Box = FBoxMinAndMax(FIntVector(-1, -1, -1), FIntVector(1, 2, 3));
+
+		// Negative Z
+		Box += FIntVector(0, 0, -5); // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[Z-,A] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(0, 0, -3); // Intersecting
+		TestFalse(*FString::Printf(TEXT("[Z-,B] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+		Box += FIntVector(0, 0, -1); // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[Z-,C] Box%s IsInside Bounds%s"), *Box.ToString(), *Bounds.ToString()), Bounds.IsInside(Box));
+	}
+
+	// IsInside(FIntVector) Test
+	{
+		FBoxMinAndMax Bounds(FIntVector(-4, -5, -6), FIntVector(7, 8, 9));
+		FIntVector Cell {0};
+
+		// Completely inside, no coincident face
+		TestTrue(*FString::Printf(TEXT("Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+
+		// Positive X
+		Cell = {6, 0, 0}; // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[X+,A] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+		Cell = {7, 0, 0}; // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[X+,B] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+
+		// Negative X
+		Cell = {-4, 0, 0}; // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[X-,A] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+		Cell = {-5, 0, 0}; // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[X-,B] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+
+		// Positive Y
+		Cell = {0, 7, 0}; // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[Y+,A] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+		Cell = {0, 8, 0}; // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[Y+,B] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+
+		// Negative Y
+		Cell = {0, -5, 0}; // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[Y-,A] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+		Cell = {0, -6, 0}; // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[Y-,B] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+
+		// Positive Z
+		Cell = {0, 0, 8}; // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[Z+,A] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+		Cell = {0, 0, 9}; // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[Z+,B] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+
+		// Negative Z
+		Cell = {0, 0, -6}; // Inside but with coincident face
+		TestTrue(*FString::Printf(TEXT("[Z-,A] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
+		Cell = {0, 0, -7}; // Outside but with a coincident face
+		TestFalse(*FString::Printf(TEXT("[Z-,B] Cell(%s) IsInside Bounds%s"), *Cell.ToString(), *Bounds.ToString()), Bounds.IsInside(Cell));
 	}
 
 	return true;

--- a/Source/ProceduralDungeon/Private/Tests/DungeonUtilsTests.cpp
+++ b/Source/ProceduralDungeon/Private/Tests/DungeonUtilsTests.cpp
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Benoit Pelletier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "CoreTypes.h"
+#include "Containers/UnrealString.h"
+#include "Misc/AutomationTest.h"
+#include "ProceduralDungeonUtils.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FDungeonUtilsTest, "ProceduralDungeon.Utils.WeightedMaps", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::SmokeFilter)
+
+bool FDungeonUtilsTest::RunTest(const FString& Parameters)
+{
+	// Built-in types test
+	{
+		TMap<int, int> WeightedMap = {
+			{ 1, 0 },	// Weight with 0 should never be returned
+			{ 2, 1 },	// The first non-zero weight should be return for index 0
+			{ 3, 2 },	// Weights greater than 1 should be returned for as much indices
+			{ 4, 1 }	// The last one should be return when index == total weights minus one
+		};				// Out of bounds index should return default value
+
+		TestEqual(TEXT("Total Weights"), Dungeon::GetTotalWeight(WeightedMap), 4);
+		TestEqual(TEXT("Weighted value at -1"), Dungeon::GetWeightedAt(WeightedMap, -1), 0); // negative index should return default value
+		TestEqual(TEXT("Weighted value at 0"), Dungeon::GetWeightedAt(WeightedMap, 0), 2);
+		TestEqual(TEXT("Weighted value at 1"), Dungeon::GetWeightedAt(WeightedMap, 1), 3);
+		TestEqual(TEXT("Weighted value at 2"), Dungeon::GetWeightedAt(WeightedMap, 2), 3);
+		TestEqual(TEXT("Weighted value at 3"), Dungeon::GetWeightedAt(WeightedMap, 3), 4);
+		TestEqual(TEXT("Weighted value at 4"), Dungeon::GetWeightedAt(WeightedMap, 4), 0); // default int is 0
+	}
+
+	// Pointer test
+	{
+		int a = 1;
+		int b = 2;
+		int c = 3;
+		int d = 4;
+
+		TMap<int*, int> WeightedMap = {
+			{ &a, 2 },
+			{ &b, 0 },	// Weight with 0 in middle should be skipped
+			{ &c, 1 },
+			{ &d, 0 }	// The last one should not be returned if weight is 0
+		};
+
+		TestEqual(TEXT("Total Weights"), Dungeon::GetTotalWeight(WeightedMap), 3);
+		TestEqual(TEXT("Weighted pointer at -1"), Dungeon::GetWeightedAt(WeightedMap, -1), (int*)nullptr);
+		TestEqual(TEXT("Weighted pointer at 0"), Dungeon::GetWeightedAt(WeightedMap, 0), &a);
+		TestEqual(TEXT("Weighted pointer at 1"), Dungeon::GetWeightedAt(WeightedMap, 1), &a);
+		TestEqual(TEXT("Weighted pointer at 2"), Dungeon::GetWeightedAt(WeightedMap, 2), &c);
+		TestEqual(TEXT("Weighted pointer at 3"), Dungeon::GetWeightedAt(WeightedMap, 3), (int*)nullptr);
+	}
+
+	return true;
+}
+
+#endif //WITH_DEV_AUTOMATION_TESTS

--- a/Source/ProceduralDungeon/Private/Tests/RoomDataTests.cpp
+++ b/Source/ProceduralDungeon/Private/Tests/RoomDataTests.cpp
@@ -27,6 +27,7 @@
 #include "Misc/AutomationTest.h"
 #include "RoomData.h"
 #include "UObject/StrongObjectPtr.h"
+#include "UObject/Package.h"
 
 #if WITH_DEV_AUTOMATION_TESTS
 

--- a/Source/ProceduralDungeon/Private/Tests/RoomDataTests.cpp
+++ b/Source/ProceduralDungeon/Private/Tests/RoomDataTests.cpp
@@ -1,0 +1,204 @@
+/*
+* MIT License
+*
+* Copyright (c) 2024 Benoit Pelletier
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#include "CoreTypes.h"
+#include "Containers/UnrealString.h"
+#include "Misc/AutomationTest.h"
+#include "RoomData.h"
+#include "UObject/StrongObjectPtr.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FRoomDataTests, "ProceduralDungeon.Types.RoomData", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::EngineFilter)
+
+// Utility to create room data
+#define CREATE_ROOM_DATA(Data) \
+	TStrongObjectPtr<URoomData> Data(NewObject<URoomData>(GetTransientPackage(), #Data)); \
+	Data->Doors.Empty();
+
+bool FRoomDataTests::RunTest(const FString& Parameters)
+{
+	// Test IsRoomInBounds
+	{
+		// Creating this room data (X is the room origin, v is the door), thus we could test rotated bounds:
+		//		1 +---+---+---+
+		//		  |   | X |   |
+		//		0 +---+---+---+
+		//		  |   |   |   |
+		//	   -1 +---+---+---+
+		//		  |   |   |   |
+		//	   -2 +---+-v-+---+
+		//		 -1   0   1   2
+		CREATE_ROOM_DATA(RoomData);
+		RoomData->FirstPoint = FIntVector(-2, -1, -1);
+		RoomData->SecondPoint = FIntVector(1, 2, 2);
+
+		FDoorDef Door;
+		Door.Position = FIntVector(-2, 0, 0);
+		Door.Direction = EDoorDirection::South;
+		RoomData->Doors.Add(Door);
+
+		// If we want to limit the dungeon cells from -2 to 2,
+		// we need to create a box from -2 to 3 (see below).
+		//		+---+---+---+---+---+
+		//		|-2 |-1 | 0 | 1 | 2 |
+		//		+---+---+---+---+---+
+		//	   -2  -1   0   1   2   3
+		FBoxMinAndMax DungeonBounds({-1000, -2, -1000}, {1000, 3, 1000});
+
+		FBoxMinAndMax RoomBoundsAtDoorLocation = RoomData->GetIntBounds() - Door.Position;
+
+		// Rotated to South
+		{
+			FBoxMinAndMax RotatedRoomBounds = Rotate(RoomBoundsAtDoorLocation, EDoorDirection::North);
+			TestEqual(TEXT("[S] Rotated Room Bounds: ((0, -1, -1), (3, 2, 2))"), RotatedRoomBounds, FBoxMinAndMax({0, -1, -1}, {3, 2, 2}));
+
+			Door.Direction = EDoorDirection::South;
+			Door.Position = {0, 0, 0};
+			TestTrue(TEXT("[S] Inside with no coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			// Positive Y
+
+			Door.Position = {0, 1, 0};
+			TestTrue(TEXT("[S] Inside with Y+ as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, 2, 0};
+			TestFalse(TEXT("[S] Intersecting in Y+"), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, 4, 0};
+			TestFalse(TEXT("[S] Outside with Y+ as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			// Negative Y
+
+			Door.Position = {0, -1, 0};
+			TestTrue(TEXT("[S] Inside with Y- as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, -2, 0};
+			TestFalse(TEXT("[S] Intersecting in Y-"), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, -4, 0};
+			TestFalse(TEXT("[S] Outside with Y- as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+		}
+
+		// Rotated to East
+		{
+			FBoxMinAndMax RotatedRoomBounds = Rotate(RoomBoundsAtDoorLocation, EDoorDirection::West);
+			TestEqual(TEXT("[E] Rotated Room Bounds: ((-1, -2, -1), (2, 1, 2))"), RotatedRoomBounds, FBoxMinAndMax({-1, -2, -1}, {2, 1, 2}));
+
+			Door.Direction = EDoorDirection::East;
+			Door.Position = {0, 1, 0};
+			TestTrue(TEXT("[E] Inside with no coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			// Positive Y
+
+			Door.Position = {0, 2, 0};
+			TestTrue(TEXT("[E] Inside with Y+ as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, 3, 0};
+			TestFalse(TEXT("[E] Intersecting in Y+"), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, 5, 0};
+			TestFalse(TEXT("[E] Outside with Y+ as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			// Negative Y
+
+			Door.Position = {0, 0, 0};
+			TestTrue(TEXT("[E] Inside with Y- as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, -1, 0};
+			TestFalse(TEXT("[E] Intersecting in Y-"), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, -3, 0};
+			TestFalse(TEXT("[E] Outside with Y- as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+		}
+
+		// Rotated to West
+		{
+			FBoxMinAndMax RotatedRoomBounds = Rotate(RoomBoundsAtDoorLocation, EDoorDirection::East);
+			TestEqual(TEXT("[W] Rotated Room Bounds: ((-1, 0, -1), (2, 3, 2))"), RotatedRoomBounds, FBoxMinAndMax({-1, 0, -1}, {2, 3, 2}));
+
+			Door.Direction = EDoorDirection::West;
+			Door.Position = {0, -1, 0};
+			TestTrue(TEXT("[W] Inside with no coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			// Positive Y
+
+			Door.Position = {0, 0, 0};
+			TestTrue(TEXT("[W] Inside with Y+ as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, 1, 0};
+			TestFalse(TEXT("[W] Intersecting in Y+"), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, 3, 0};
+			TestFalse(TEXT("[W] Outside with Y+ as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			// Negative Y
+
+			Door.Position = {0, -2, 0};
+			TestTrue(TEXT("[W] Inside with Y- as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, -3, 0};
+			TestFalse(TEXT("[W] Intersecting in Y-"), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, -5, 0};
+			TestFalse(TEXT("[W] Outside with Y- as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+		}
+
+		// Rotated to North
+		{
+			FBoxMinAndMax RotatedRoomBounds = Rotate(RoomBoundsAtDoorLocation, EDoorDirection::South);
+			TestEqual(TEXT("[N] Rotated Room Bounds: ((-2, -1, -1), (1, 2, 2))"), RotatedRoomBounds, FBoxMinAndMax({-2, -1, -1}, {1, 2, 2}));
+
+			Door.Direction = EDoorDirection::North;
+			Door.Position = {0, 0, 0};
+			TestTrue(TEXT("[N] Inside with no coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			// Positive Y
+
+			Door.Position = {0, 1, 0};
+			TestTrue(TEXT("[N] Inside with Y+ as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, 2, 0};
+			TestFalse(TEXT("[N] Intersecting in Y+"), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, 4, 0};
+			TestFalse(TEXT("[N] Outside with Y+ as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			// Negative Y
+
+			Door.Position = {0, -1, 0};
+			TestTrue(TEXT("[N] Inside with Y- as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, -2, 0};
+			TestFalse(TEXT("[N] Intersecting in Y-"), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+
+			Door.Position = {0, -4, 0};
+			TestFalse(TEXT("[N] Outside with Y- as coincident face."), RoomData->IsRoomInBounds(DungeonBounds, 0, Door));
+		}
+	}
+
+	return true;
+}
+
+#endif //WITH_DEV_AUTOMATION_TESTS

--- a/Source/ProceduralDungeon/Public/Components/StaticRoomVisibilityComponent.h
+++ b/Source/ProceduralDungeon/Public/Components/StaticRoomVisibilityComponent.h
@@ -1,0 +1,81 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Benoit Pelletier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "ProceduralDungeonTypes.h"
+#include "StaticRoomVisibilityComponent.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FRoomVisibilityEvent, AActor*, Actor, bool, IsInVisibleRoom);
+
+UCLASS(ClassGroup = "ProceduralDungeon", meta = (BlueprintSpawnableComponent, DisplayName = "Room Visibility (Static)") )
+class PROCEDURALDUNGEON_API UStaticRoomVisibilityComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+	UStaticRoomVisibilityComponent();
+
+	virtual void BeginPlay() override;
+	virtual void EndPlay(EEndPlayReason::Type Reason) override;
+
+	void SetVisible(UObject* Owner, bool Visible);
+	void ResetVisible(UObject* Owner); // Same as SetVisible(Owner, false)
+
+	// Returns true if the actor is in a visible room.
+	// Always returns true when "Occlude Dynamic Actors" is unchecked in the plugin's settings
+	// Useful with "Custom" visibility.
+	UFUNCTION(BlueprintPure, Category = "Procedural Dungeon", meta = (CompactNodeTitle = "Is In Visible Room", DisplayName = "Is In Visible Room"))
+	bool IsVisible();
+
+	UFUNCTION(BlueprintSetter)
+	void SetVisibilityMode(EVisibilityMode Mode);
+
+	UFUNCTION(BlueprintGetter)
+	FORCEINLINE EVisibilityMode GetVisibilityMode() const { return VisibilityMode; }
+
+public:
+	// Called when the visibility from rooms changed (either by a room visibility change or by this actor moving between rooms).
+	// Useful to update a "Custom" visibility.
+	UPROPERTY(BlueprintAssignable, Category = "Procedural Dungeon")
+	FRoomVisibilityEvent OnRoomVisibilityChanged;
+
+protected:
+	ARoomLevel* GetOwnerRoomLevel() const;
+	void UpdateVisibility();
+	void RegisterVisibilityDelegate(ARoomLevel* RoomLevel,  bool Register);
+
+	UFUNCTION()
+	void RoomVisibilityChanged(class ARoomLevel* RoomLevel, bool IsVisible);
+
+private:
+	void CleanEnablers();
+
+	TSet<TWeakObjectPtr<UObject>> VisibilityEnablers {};
+
+	UPROPERTY(EditAnywhere, BlueprintGetter = GetVisibilityMode, BlueprintSetter = SetVisibilityMode, Category = "Procedural Dungeon", meta = (AllowPrivateAccess = true))
+	EVisibilityMode VisibilityMode {EVisibilityMode::Default};
+};

--- a/Source/ProceduralDungeon/Public/Door.h
+++ b/Source/ProceduralDungeon/Public/Door.h
@@ -104,5 +104,8 @@ protected:
 	bool bAlwaysUnlocked {false};
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Door", meta = (DisplayName = "Door Type"))
-	UDoorType* Type;
+	UDoorType* Type {nullptr};
+
+	UPROPERTY(EditAnywhere, Category = "Door")
+	USceneComponent* DefaultSceneComponent {nullptr};
 };

--- a/Source/ProceduralDungeon/Public/DungeonGenerator.h
+++ b/Source/ProceduralDungeon/Public/DungeonGenerator.h
@@ -316,8 +316,6 @@ private:
 	uint32 Seed;
 
 	static uint32 GeneratorCount;
-	static const uint32 MaxTry {500};
-	static const uint32 MaxRoomTry {10};
 
 	FRandomStream Random;
 

--- a/Source/ProceduralDungeon/Public/DungeonGenerator.h
+++ b/Source/ProceduralDungeon/Public/DungeonGenerator.h
@@ -32,7 +32,8 @@
 #include "DungeonGenerator.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FGenerationEvent);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FRoomEvent, const URoomData*, NewRoom);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FRoomEvent, const URoomData*, Room);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FRoomDoorEvent, const URoomData*, Room, const FDoorDef&, Door);
 
 class ADoor;
 class URoom;
@@ -196,6 +197,10 @@ public:
 	UFUNCTION(BlueprintNativeEvent, Category = "Dungeon Generator", meta = (DisplayName = "On Room Added"))
 	void OnRoomAdded(const URoomData* NewRoom);
 
+	// Called each time no room could have been placed at a door (all room placement tries have been exhausted).
+	UFUNCTION(BlueprintNativeEvent, Category = "Dungeon Generator", meta = (DisplayName = "Failed To Add Room"))
+	void OnFailedToAddRoom(const URoomData* FromRoom, const FDoorDef& FromDoor);
+
 	// ===== Utility functions you can use in blueprint =====
 
 	// Return true if a specific RoomData is already in the dungeon
@@ -280,6 +285,10 @@ public:
 	// Those rooms can be destroyed without loading them if the generation try is not valid.
 	UPROPERTY(BlueprintAssignable, Category = "Dungeon Generator")
 	FRoomEvent OnRoomAddedEvent;
+
+	// Called each time no room could have been placed at a door (all room placement tries have been exhausted).
+	UPROPERTY(BlueprintAssignable, Category = "Dungeon Generator")
+	FRoomDoorEvent OnFailedToAddRoomEvent;
 
 private:
 	// Create virtually the dungeon (no load nor initialization of room levels)

--- a/Source/ProceduralDungeon/Public/DungeonGenerator.h
+++ b/Source/ProceduralDungeon/Public/DungeonGenerator.h
@@ -48,7 +48,12 @@ enum class EGenerationResult : uint8
 	Success
 };
 
-USTRUCT(BlueprintType)
+// Holds the settings for the dungeon limits.
+// These values are expressed in Room cells, and are based on the origin of the first room (0,0,0).
+// For example, if the first room is only 1 room cell (`FirstPoint = (0,0,0)`, `SecondPoint = (1,1,1)`), then  this is the cell (0,0,0).
+// If you set a `MinY=2` et `MaxY=2`, then on the Y axis the dungeon can go from the cell -2 to cell 2,
+// Making an effective range of 5 cells, centered on the first room.
+USTRUCT(BlueprintType, meta = (ShortToolTip = "Holds the settings for the dungeon limits."))
 struct FBoundsParams
 {
 	GENERATED_BODY()
@@ -106,22 +111,22 @@ public:
 	FBoxMinAndMax GetBox() const;
 };
 
+// This is the main actor of the plugin. The dungeon generator is responsible to generate dungeons and replicate them over the network. 
 UCLASS(Blueprintable, ClassGroup = "Procedural Dungeon")
 class PROCEDURALDUNGEON_API ADungeonGenerator : public AActor
 {
 	GENERATED_BODY()
 
 public:
-	// Sets default values for this actor's properties
 	ADungeonGenerator();
 
 protected:
-	// Called when the game starts or when spawned
+	//~ Begin AActor Interface
 	virtual void BeginPlay() override;
 	virtual void EndPlay(EEndPlayReason::Type EndPlayReason) override;
 	virtual void Tick(float DeltaTime) override;
-
 	virtual bool ReplicateSubobjects(UActorChannel* Channel, FOutBunch* Bunch, FReplicationFlags* RepFlags) override;
+	//~ End AActor Interface
 
 public:
 
@@ -250,9 +255,15 @@ public:
 	int GetNbRoom();
 
 	// Returns an array of room data with compatible at least one compatible door with the door data provided.
+	// @param bSuccess True if at least one compatible room data was found.
+	// @param CompatibleRooms Filled with all compatible room data found.
+	// @param RoomDataArray The list of room data to check for compatibility.
+	// @param DoorData The door used to check if a room is compatible.
 	UFUNCTION(BlueprintPure, Category = "Dungeon Generator")
 	void GetCompatibleRoomData(bool& bSuccess, TArray<URoomData*>& CompatibleRooms, const TArray<URoomData*>& RoomDataArray, const FDoorDef& DoorData);
 
+	// Access to the random stream of the procedural dungeon. You should always use this for the procedural generation.
+	// @return The random stream used by the dungeon generator.
 	UFUNCTION(BlueprintPure, Category = "Dungeon Generator")
 	const FRandomStream& GetRandomStream() { return Random; }
 

--- a/Source/ProceduralDungeon/Public/DungeonGenerator.h
+++ b/Source/ProceduralDungeon/Public/DungeonGenerator.h
@@ -307,6 +307,8 @@ public:
 	FVector GetDungeonOffset() const;
 	FQuat GetDungeonRotation() const;
 
+	FORCEINLINE const UDungeonGraph* GetRooms() const { return Graph; }
+
 protected:
 	UPROPERTY(BlueprintReadOnly, Replicated, Category = "Dungeon Generator", meta = (DisplayName = "Rooms"))
 	UDungeonGraph* Graph;

--- a/Source/ProceduralDungeon/Public/DungeonGenerator.h
+++ b/Source/ProceduralDungeon/Public/DungeonGenerator.h
@@ -193,6 +193,10 @@ public:
 	UFUNCTION(BlueprintPure, Category = "Dungeon Generator")
 	const FRandomStream& GetRandomStream() { return Random; }
 
+	// Returns the current generation progress.
+	UFUNCTION(BlueprintPure, Category = "Dungeon Generator")
+	float GetProgress() const;
+
 	URoom* GetRoomByIndex(int64 Index) const;
 
 	// ===== Events =====
@@ -308,6 +312,7 @@ public:
 	FQuat GetDungeonRotation() const;
 
 	FORCEINLINE const UDungeonGraph* GetRooms() const { return Graph; }
+	FORCEINLINE EGenerationState GetCurrentState() const { return CurrentState; }
 
 protected:
 	UPROPERTY(BlueprintReadOnly, Replicated, Category = "Dungeon Generator", meta = (DisplayName = "Rooms"))
@@ -342,4 +347,7 @@ private:
 
 	// Transient. Only used to detect when occlusion distance is changed.
 	uint32 PreviousOcclusionDistance {0};
+
+	// Transient. Used to count unloaded/loaded/initialized rooms during generation.
+	int32 CachedTmpRoomCount {0};
 };

--- a/Source/ProceduralDungeon/Public/DungeonGenerator.h
+++ b/Source/ProceduralDungeon/Public/DungeonGenerator.h
@@ -47,6 +47,64 @@ enum class EGenerationResult : uint8
 	Success
 };
 
+USTRUCT(BlueprintType)
+struct FBoundsParams
+{
+	GENERATED_BODY()
+
+public:
+	// Enables the X limit in positive axis (north from the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (InlineEditConditionToggle))
+	bool bLimitMaxX {false};
+
+	// The X positive limit (north) of the dungeon in room units (starting from the origin of the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (EditCondition = "bLimitMaxX", UIMin = 0, ClampMin = 0))
+	int32 MaxX {0};
+
+	// Enables the X limit in negative axis (south from the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (InlineEditConditionToggle))
+	bool bLimitMinX {false};
+
+	// The X negative limit (south) of the dungeon in room units (starting from the origin of the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (EditCondition = "bLimitMinX", UIMin = 0, ClampMin = 0))
+	int32 MinX {0};
+
+	// Enables the Y limit in positive axis (east from the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (InlineEditConditionToggle))
+	bool bLimitMaxY {false};
+
+	// The Y positive limit (east) of the dungeon in room units (starting from the origin of the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (EditCondition = "bLimitMaxY", UIMin = 0, ClampMin = 0))
+	int32 MaxY {0};
+
+	// Enables the Y limit in negative axis (west from the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (InlineEditConditionToggle))
+	bool bLimitMinY {false};
+
+	// The Y negative limit (west) of the dungeon in room units (starting from the origin of the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (EditCondition = "bLimitMinY", UIMin = 0, ClampMin = 0))
+	int32 MinY {0};
+
+	// Enables the Z limit in positive axis (up from the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (InlineEditConditionToggle))
+	bool bLimitMaxZ {false};
+
+	// The Z positive limit (up) of the dungeon in room units (starting from the origin of the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (EditCondition = "bLimitMaxZ", UIMin = 0, ClampMin = 0))
+	int32 MaxZ {0};
+
+	// Enables the Z limit in negative axis (down from the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (InlineEditConditionToggle))
+	bool bLimitMinZ {false};
+
+	// The Z negative limit (down) of the dungeon in room units (starting from the origin of the first room).
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation|Boundq Limits", meta = (EditCondition = "bLimitMinZ", UIMin = 0, ClampMin = 0))
+	int32 MinZ {0};
+
+public:
+	FBoxMinAndMax GetBox() const;
+};
+
 UCLASS(Blueprintable, ClassGroup = "Procedural Dungeon")
 class PROCEDURALDUNGEON_API ADungeonGenerator : public AActor
 {
@@ -289,6 +347,9 @@ public:
 	// (will only have effect if the deprecated CanLoop in the plugin settings is ticked too, until it is removed in a future version)
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation")
 	bool bCanLoop {true};
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Generation")
+	FBoundsParams DungeonLimits;
 
 	// If ticked, when trying to place a new room during a dungeon generation,
 	// a box overlap test will be made to make sure the room will not spawn

--- a/Source/ProceduralDungeon/Public/DungeonGenerator.h
+++ b/Source/ProceduralDungeon/Public/DungeonGenerator.h
@@ -176,15 +176,21 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Dungeon Generator")
 	URoomData* GetRandomRoomData(TArray<URoomData*> RoomDataArray);
 
+	// Return a random RoomData from the weighted map provided.
+	// For example: you have RoomA with weight 1 and RoomB with weight 2,
+	// then RoomA has proba of 1/3 and RoomB 2/3 to be returned.
+	UFUNCTION(BlueprintCallable, Category = "Dungeon Generator")
+	URoomData* GetRandomRoomDataWeighted(const TMap<URoomData*, int>& RoomDataWeightedMap);
+
 	// Returns the current number of room in the generated dungeon.
-	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Dungeon Generator", meta = (DisplayName = "Room Count", CompactNodeTitle = "Room Count", DeprecatedFunction, DeprecationMessage = "Use the same function from the Rooms variable."))
+	UFUNCTION(BlueprintPure, Category = "Dungeon Generator", meta = (DisplayName = "Room Count", CompactNodeTitle = "Room Count", DeprecatedFunction, DeprecationMessage = "Use the same function from the Rooms variable."))
 	int GetNbRoom();
 
 	// Returns an array of room data with compatible at least one compatible door with the door data provided.
-	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Dungeon Generator")
+	UFUNCTION(BlueprintPure, Category = "Dungeon Generator")
 	void GetCompatibleRoomData(bool& bSuccess, TArray<URoomData*>& CompatibleRooms, const TArray<URoomData*>& RoomDataArray, const FDoorDef& DoorData);
 
-	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Dungeon Generator")
+	UFUNCTION(BlueprintPure, Category = "Dungeon Generator")
 	const FRandomStream& GetRandomStream() { return Random; }
 
 	URoom* GetRoomByIndex(int64 Index) const;

--- a/Source/ProceduralDungeon/Public/DungeonGraph.h
+++ b/Source/ProceduralDungeon/Public/DungeonGraph.h
@@ -42,6 +42,8 @@ enum class EDungeonGraphState : uint8
 	NbState
 };
 
+// Holds the generated dungeon.
+// You can access the rooms using many functions.
 UCLASS(BlueprintType)
 class PROCEDURALDUNGEON_API UDungeonGraph : public UReplicableObject
 {

--- a/Source/ProceduralDungeon/Public/DungeonGraph.h
+++ b/Source/ProceduralDungeon/Public/DungeonGraph.h
@@ -153,9 +153,9 @@ protected:
 	// Sync Rooms and ReplicatedRooms arrays
 	void SynchronizeRooms();
 
-	bool AreRoomsLoaded() const;
-	bool AreRoomsUnloaded() const;
-	bool AreRoomsInitialized() const;
+	bool AreRoomsLoaded(int32& NbRoomLoaded) const;
+	bool AreRoomsUnloaded(int32& NbRoomUnloaded) const;
+	bool AreRoomsInitialized(int32& NbRoomInitialized) const;
 
 	void RequestGeneration();
 	void RequestUnload();

--- a/Source/ProceduralDungeon/Public/ProceduralDungeonSettings.h
+++ b/Source/ProceduralDungeon/Public/ProceduralDungeonSettings.h
@@ -29,7 +29,8 @@
 #include "Engine/EngineTypes.h"
 #include "ProceduralDungeonSettings.generated.h"
 
-UCLASS(config = Game, defaultconfig)
+// Holds the plugin's settings.
+UCLASS(Config = Game, DefaultConfig)
 class PROCEDURALDUNGEON_API UProceduralDungeonSettings : public UObject
 {
 	GENERATED_BODY()

--- a/Source/ProceduralDungeon/Public/ProceduralDungeonSettings.h
+++ b/Source/ProceduralDungeon/Public/ProceduralDungeonSettings.h
@@ -62,6 +62,14 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "General")
 	TEnumAsByte<ECollisionChannel> RoomObjectType {ECollisionChannel::ECC_EngineTraceChannel6};
 
+	// The number of dungeon generation retry before the generator gives up.
+	UPROPERTY(EditAnywhere, config, Category = "General", AdvancedDisplay, meta = (UIMin = 1, ClampMin = 1))
+	int32 MaxGenerationTry;
+
+	// The number of room placement retry on a specific door before the generator gives up and continues with the next door.
+	UPROPERTY(EditAnywhere, config, Category = "General", AdvancedDisplay, meta = (UIMin = 1, ClampMin = 1))
+	int32 MaxRoomPlacementTry;
+
 	// The rooms visibility will be toggled off when the player is not inside it or in a room next to it.
 	UPROPERTY(EditAnywhere, config, Category = "Occlusion Culling", meta = (DisplayName = "Enable Occlusion Culling"))
 	bool OcclusionCulling;

--- a/Source/ProceduralDungeon/Public/ProceduralDungeonTypes.h
+++ b/Source/ProceduralDungeon/Public/ProceduralDungeonTypes.h
@@ -86,6 +86,17 @@ enum class ESeedType : uint8
 	NbType = 3 				UMETA(Hidden)
 };
 
+// Visibility mode for Room Visibilty Components.
+UENUM(BlueprintType, meta = (DisplayName = "Room Visibility"))
+enum class EVisibilityMode : uint8
+{
+	Default			UMETA(DisplayName = "Same As Room"),
+	ForceVisible	UMETA(DisplayName = "Force Visible"),
+	ForceHidden		UMETA(DisplayName = "Force Hidden"),
+	Custom			UMETA(DisplayName = "Custom"),
+	NbMode			UMETA(Hidden)
+};
+
 USTRUCT(BlueprintType)
 struct PROCEDURALDUNGEON_API FDoorDef
 {

--- a/Source/ProceduralDungeon/Public/ProceduralDungeonTypes.h
+++ b/Source/ProceduralDungeon/Public/ProceduralDungeonTypes.h
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2023 Benoit Pelletier
+ * Copyright (c) 2019-2024 Benoit Pelletier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -118,6 +118,7 @@ public:
 	FVector GetDoorSize() const;
 	FString GetTypeName() const;
 	FString ToString() const;
+	FDoorDef GetOpposite() const;
 
 	static FVector GetRealDoorPosition(FIntVector DoorCell, EDoorDirection DoorRot, bool includeOffset = true);
 
@@ -129,6 +130,8 @@ public:
 
 // TODO: Use UE built-in TBox<FIntVector> instead?
 // The downside of doing that would be the Center and Extent computation that is slightly different...
+// Also, the IsInside with another box does not consider coincident faces as inside...
+// Also, operators + and += don't mean the same (extending box to include a point instead of shifting the box)...
 struct PROCEDURALDUNGEON_API FBoxMinAndMax
 {
 public:
@@ -140,8 +143,11 @@ public:
 	FBoxMinAndMax(const FIntVector& A, const FIntVector& B);
 
 	FIntVector GetSize() const;
-
 	FBoxCenterAndExtent ToCenterAndExtent() const;
+	bool IsInside(const FIntVector& Cell) const;
+	bool IsInside(const FBoxMinAndMax& Other) const;
+	void Rotate(const EDoorDirection& Rot);
+	FString ToString() const;
 
 	static bool Overlap(const FBoxMinAndMax& A, const FBoxMinAndMax& B);
 
@@ -149,6 +155,8 @@ public:
 	FBoxMinAndMax& operator-=(const FIntVector& X);
 	FBoxMinAndMax operator+(const FIntVector& X) const;
 	FBoxMinAndMax operator-(const FIntVector& X) const;
+	bool operator==(const FBoxMinAndMax& Other) const;
+	bool operator!=(const FBoxMinAndMax& Other) const;
 };
 
 FBoxMinAndMax PROCEDURALDUNGEON_API Rotate(const FBoxMinAndMax& Box, const EDoorDirection& Rot);

--- a/Source/ProceduralDungeon/Public/ProceduralDungeonUtils.h
+++ b/Source/ProceduralDungeon/Public/ProceduralDungeonUtils.h
@@ -101,6 +101,8 @@ namespace Dungeon
 	float PROCEDURALDUNGEON_API DoorArrowHeadSize();
 	bool PROCEDURALDUNGEON_API CanLoop();
 	ECollisionChannel PROCEDURALDUNGEON_API RoomObjectType();
+	uint32 PROCEDURALDUNGEON_API MaxGenerationTryBeforeGivingUp();
+	uint32 PROCEDURALDUNGEON_API MaxRoomPlacementTryBeforeGivingUp();
 
 	void PROCEDURALDUNGEON_API EnableOcclusionCulling(bool Enable);
 	void PROCEDURALDUNGEON_API SetOcclusionDistance(int32 Distance);

--- a/Source/ProceduralDungeon/Public/ProceduralDungeonUtils.h
+++ b/Source/ProceduralDungeon/Public/ProceduralDungeonUtils.h
@@ -58,6 +58,33 @@ namespace Dungeon
 	// Returns the real world snapped location to the nearest point in room units from a real world point
 	FVector PROCEDURALDUNGEON_API SnapPoint(FVector Point);
 
+	template<typename T>
+	int GetTotalWeight(const TMap<T, int>& WeightMap)
+	{
+		int Total = 0;
+		for (const auto& Pair : WeightMap)
+		{
+			Total += Pair.Value;
+		}
+		return Total;
+	}
+
+	template<typename T>
+	T GetWeightedAt(const TMap<T, int>& WeightMap, int Index)
+	{
+		if (Index < 0)
+			return T();
+
+		int Current = 0;
+		for (const auto& Pair : WeightMap)
+		{
+			Current += Pair.Value;
+			if (Current > Index)
+				return Pair.Key;
+		}
+		return T();
+	}
+
 	// ===== Plugin's Settings =====
 
 	FVector PROCEDURALDUNGEON_API RoomUnit();

--- a/Source/ProceduralDungeon/Public/RoomData.h
+++ b/Source/ProceduralDungeon/Public/RoomData.h
@@ -92,6 +92,7 @@ public:
 
 #if !(UE_BUILD_SHIPPING) || WITH_EDITOR
 	bool IsDoorValid(int DoorIndex) const;
+	bool IsDoorDuplicate(int DoorIndex) const;
 #endif // !(UE_BUILD_SHIPPING) || WITH_EDITOR
 
 #if WITH_EDITOR

--- a/Source/ProceduralDungeon/Public/RoomData.h
+++ b/Source/ProceduralDungeon/Public/RoomData.h
@@ -84,6 +84,9 @@ public:
 	UFUNCTION(BlueprintNativeEvent, Category = "Room Data")
 	void InitializeRoom(URoom* Room, UDungeonGraph* Dungeon) const;
 
+	UFUNCTION(BlueprintNativeEvent, Category = "Room Data")
+	void CleanupRoom(URoom* Room, UDungeonGraph* Dungeon) const;
+
 	FIntVector GetSize() const;
 	class FBoxCenterAndExtent GetBounds(FTransform Transform = FTransform::Identity) const;
 	FBoxMinAndMax GetIntBounds() const;

--- a/Source/ProceduralDungeon/Public/RoomData.h
+++ b/Source/ProceduralDungeon/Public/RoomData.h
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2019-2021, 2023 Benoit Pelletier
+ * Copyright (c) 2019-2024 Benoit Pelletier
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,8 +50,6 @@ class PROCEDURALDUNGEON_API URoomData : public UPrimaryDataAsset
 {
 	GENERATED_BODY()
 
-	friend class UProceduralLevelStreaming;
-
 public:
 	UPROPERTY(EditInstanceOnly, Category = "Level")
 	TSoftObjectPtr<UWorld> Level {nullptr};
@@ -89,6 +87,8 @@ public:
 	FIntVector GetSize() const;
 	class FBoxCenterAndExtent GetBounds(FTransform Transform = FTransform::Identity) const;
 	FBoxMinAndMax GetIntBounds() const;
+
+	bool IsRoomInBounds(const FBoxMinAndMax& Bounds, int DoorIndex, const FDoorDef& DoorDungeonPos) const;
 
 #if !(UE_BUILD_SHIPPING) || WITH_EDITOR
 	bool IsDoorValid(int DoorIndex) const;

--- a/Source/ProceduralDungeon/Public/RoomVisibilityComponent.h
+++ b/Source/ProceduralDungeon/Public/RoomVisibilityComponent.h
@@ -25,66 +25,20 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Components/ActorComponent.h"
+#include "Components/StaticRoomVisibilityComponent.h"
 #include "RoomVisitor.h"
 #include "RoomVisibilityComponent.generated.h"
 
-UENUM(BlueprintType, meta = (DisplayName = "Room Visibility"))
-enum class EVisibilityMode : uint8
-{
-	Default			UMETA(DisplayName = "Same As Room"),
-	ForceVisible	UMETA(DisplayName = "Force Visible"),
-	ForceHidden		UMETA(DisplayName = "Force Hidden"),
-	Custom			UMETA(DisplayName = "Custom"),
-	NbMode			UMETA(Hidden)
-};
-
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FRoomVisibilityEvent, AActor*, Actor, bool, IsInVisibleRoom);
-
 UCLASS(ClassGroup = "ProceduralDungeon", meta = (BlueprintSpawnableComponent, DisplayName = "Room Visibility"))
-class PROCEDURALDUNGEON_API URoomVisibilityComponent : public UActorComponent, public IRoomVisitor
+class PROCEDURALDUNGEON_API URoomVisibilityComponent : public UStaticRoomVisibilityComponent, public IRoomVisitor
 {
 	GENERATED_BODY()
 
 public:
 	URoomVisibilityComponent();
 
-	virtual void BeginPlay() override;
-
 	//~ BEGIN IRoomVisitor
 	virtual void OnRoomEnter_Implementation(ARoomLevel* RoomLevel) override;
 	virtual void OnRoomExit_Implementation(ARoomLevel* RoomLevel) override;
 	//~ END IRoomVisitor
-
-	void SetVisible(UObject* Owner, bool Visible);
-	void ResetVisible(UObject* Owner); // Same as SetVisible(Owner, false)
-
-	// Returns true if the actor is in a visible room.
-	// Always returns true when "Occlude Dynamic Actors" is unchecked in the plugin's settings
-	// Useful with "Custom" visibility.
-	UFUNCTION(BlueprintPure, Category = "Procedural Dungeon", meta = (CompactNodeTitle = "Is In Visible Room", DisplayName = "Is In Visible Room"))
-	bool IsVisible();
-
-	UFUNCTION(BlueprintCallable, Category = "Procedural Dungeon", meta = (DisplayName = "Set Visibility"))
-	void SetVisibilityMode(EVisibilityMode Mode);
-
-	UFUNCTION(BlueprintPure, Category = "Procedural Dungeon", meta = (CompactNodeTitle = "Visibility", DisplayName = "Get Visibility"))
-	FORCEINLINE EVisibilityMode GetVisibilityMode() { return VisibilityMode; }
-
-	// Called when the visibility from rooms changed (either by a room visibility change or by this actor moving between rooms).
-	// Useful to update a "Custom" visibility.
-	UPROPERTY(BlueprintAssignable, Category = "Procedural Dungeon")
-	FRoomVisibilityEvent OnRoomVisibilityChanged;
-
-protected:
-	void UpdateVisibility();
-
-	UFUNCTION()
-	void RoomVisibilityChanged(class ARoomLevel* RoomLevel, bool IsVisible);
-
-private:
-	void CleanEnablers();
-
-	TSet<TWeakObjectPtr<UObject>> VisibilityEnablers;
-	EVisibilityMode VisibilityMode;
 };

--- a/Source/ProceduralDungeonEditor/Private/EditorMode/SProceduralDungeonEdModeWidget.cpp
+++ b/Source/ProceduralDungeonEditor/Private/EditorMode/SProceduralDungeonEdModeWidget.cpp
@@ -474,7 +474,7 @@ FReply SProceduralDungeonEdModeWidget::RemoveInvalidDoors()
 	Data->Modify();
 	for (int i = Data->Doors.Num() - 1; i >= 0; --i)
 	{
-		if (!Data->IsDoorValid(i))
+		if (!Data->IsDoorValid(i) || Data->IsDoorDuplicate(i))
 			Data->Doors.RemoveAt(i);
 	}
 	GEditor->EndTransaction();

--- a/Source/ProceduralDungeonEditor/Private/EditorMode/SProceduralDungeonEdModeWidget.cpp
+++ b/Source/ProceduralDungeonEditor/Private/EditorMode/SProceduralDungeonEdModeWidget.cpp
@@ -351,6 +351,12 @@ void SProceduralDungeonEdModeWidget::OnDataAssetChanged()
 	if (IsValidRoomData(EdMode, &CachedData))
 	{
 		DataContentWidget->SetObject(CachedData.Get());
+		if (CachedData->Level.IsNull())
+		{
+			CachedData->Modify();
+			CachedData->Level = EdMode->GetWorld();
+			DungeonEd_LogInfo("Room Data's Level asset filled with current editor's Level.");
+		}
 		DataDelegateHandle = CachedData->OnPropertiesChanged.AddLambda([this](URoomData* Data) { UpdateErrorText(); });
 	}
 
@@ -370,7 +376,7 @@ FReply SProceduralDungeonEdModeWidget::ReparentLevelActor()
 	ULevelScriptBlueprint* LevelBlueprint = World->PersistentLevel->GetLevelScriptBlueprint();
 	if (!IsValid(LevelBlueprint))
 	{
-		DungeonEd_LogInfo("ERROR: Can't Reparent Level Blueprint for an unknown reason.");
+		DungeonEd_LogError("ERROR: Can't Reparent Level Blueprint for an unknown reason.");
 		return FReply::Unhandled();
 	}
 


### PR DESCRIPTION
New features:
- Added a blueprint node to select a random room with weights (non-uniform random).
- Added dungeon limits for room placement. If set, rooms will not be placed outside of the limits.
- Added a `Static Room Visibility` component with reduced computation over the non-static one (used for directly placed actors in room levels that will never go out of it at runtime).
- Directly placed actors in room levels with the tag `Ignore Room Culling` will be ignored by the room level (before, only replicated actors were ignored). You can use a ` (Static) Room Visibility` component to manage their visibility instead.
- Can now tweak the max generation tries and max room placement tries in the plugin's settings.
- Added accessor to generator's `Rooms` variable in C++ outside of child classes.
- The door debug box (blue) will now turn orange if multiple doors are on the same place.
- Now the `RoomData`'s level will be automatically filled if empty when the data is selected in the Dungeon Room Editor mode.
- Added an `On Fail To Add Room` event, called after exhausted all tries of placing a room without success.
- Added a `Cleanup Room` function in `Room Data` class as a counterpart of the `Initialize Room` one.

Fixes:
- Crash when running in new PIE window in 'Play as Client' when a DungeonGenerator actor is in the launched level.
- Fixed missing call to `On Room Added` event for the first room.
- Fixed `RootComponent` of door actors to be able to edit them in editor.
- Fixed door actors so that they always spawn, regardless of the actor's parameter.