### PR TITLE
Update debug log message in DungeonGeneratorBase.cpp

### DIFF
--- a/Source/ProceduralDungeon/Private/DungeonGeneratorBase.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGeneratorBase.cpp
@@ -68,7 +68,7 @@ void operator<<(FStructuredArchiveSlot Slot, FDungeonSaveData& Data)
 	}
 	else
 	{
-		DungeonLog_Debug("Deserialized dungeon from saved data: %d", *Data.GeneratorId.ToString());
+		DungeonLog_Debug("Deserialized dungeon from saved data: %s", *Data.GeneratorId.ToString());
 	}
 }
 


### PR DESCRIPTION
This commit changes the format specifier in the debug log message of the DungeonGeneratorBase.cpp file. The format specifier for the generator ID was changed from %d (integer) to %s (string) to correctly display the ID in the debug log.