### PR TITLE
New `TryPlaceRoomAtLocation` node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `Get Level Room Data` node accessible from actors, even during their construction script, allowing the actor to setup itself when placed in the room.
 - Added a new Data Asset called `Dungeon Settings` to allow overriding the `Room Unit` in the `Dungeon Generator` class.
 - Added a compatibility list in `Door Type` assets, so different door types may be compatible
+- Added `Try Place Room At Location` for custom dungeon algorithms to place a room without using a `Door Def` structure.
 
 ### Changed
 

--- a/Source/ProceduralDungeon/Private/DungeonGeneratorBase.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGeneratorBase.cpp
@@ -299,6 +299,24 @@ bool ADungeonGeneratorBase::TryPlaceRoom(URoom* const& Room, int DoorIndex, cons
 
 	Room->SetPositionAndRotationFromDoor(DoorIndex, TargetDoor.Position, TargetDoor.Direction);
 
+	return CheckRoomOverlap(Room, World);
+}
+
+bool ADungeonGeneratorBase::TryPlaceRoomAtLocation(URoom* const& Room, FIntVector Location, EDoorDirection Rotation, const UWorld* World) const
+{
+	if (!IsValid(Room))
+	{
+		return false;
+	}
+
+	Room->SetPosition(Location);
+	Room->SetDirection(Rotation);
+
+	return CheckRoomOverlap(Room, World);
+}
+
+bool ADungeonGeneratorBase::CheckRoomOverlap(const URoom* const& Room, const UWorld* World) const
+{
 	// Test if it fits in the place
 	bool bCanBePlaced = !URoom::Overlap(*Room, Graph->GetAllRooms());
 	// @TODO: Should be more performant to use voxel bounds instead of room bounds

--- a/Source/ProceduralDungeon/Public/DungeonGeneratorBase.h
+++ b/Source/ProceduralDungeon/Public/DungeonGeneratorBase.h
@@ -255,6 +255,14 @@ protected:
 	UFUNCTION(BlueprintCallable, BlueprintPure = false, Category = "GenerationAlgorithm", meta = (BlueprintProtected, ReturnDisplayName = "Success", HidePin = "World"))
 	bool TryPlaceRoom(URoom* const& Room, int DoorIndex, const FDoorDef& TargetDoor, const UWorld* World = nullptr) const;
 
+	// Set the position and rotation of a room instance and return true if there is nothing colliding with it.
+	UFUNCTION(BlueprintCallable, BlueprintPure = false, Category = "GenerationAlgorithm", meta = (BlueprintProtected, ReturnDisplayName = "Success", HidePin = "World"))
+	bool TryPlaceRoomAtLocation(URoom* const& Room, FIntVector Location, EDoorDirection Rotation, const UWorld* World = nullptr) const;
+
+	// Check if the room instance provided is overlapping with existing rooms in the dungeon graph.
+	// Also checks if bUseWorldCollisionChecks is true, in which case a box overlap test is made in the persistent world.
+	bool CheckRoomOverlap(const URoom* const& Room, const UWorld* World = nullptr) const;
+
 	// Finalize the room creation by adding it to the dungeon graph. OnRoomAdded is called here.
 	UFUNCTION(BlueprintCallable, Category = "GenerationAlgorithm", meta = (BlueprintProtected, ReturnDisplayName = "Success", AutoCreateRefTerm = "DoorsToConnect", AdvancedDisplay = "DoorsToConnect,bFailIfNotConnected"))
 	bool AddRoomToDungeon(URoom* const& Room, const TArray<int>& DoorsToConnect, bool bFailIfNotConnected = true);

--- a/Source/ProceduralDungeon/Public/Room.h
+++ b/Source/ProceduralDungeon/Public/Room.h
@@ -202,8 +202,6 @@ protected:
 	virtual void RegisterReplicableSubobjects(bool bRegister) override;
 	//~ End UReplicableObject Interface
 
-	void SetPosition(const FIntVector& NewPosition);
-	void SetDirection(EDoorDirection NewDirection);
 	void UpdateVisibility() const;
 
 	UFUNCTION() // Needed macro for replication to work
@@ -261,6 +259,9 @@ public:
 	FDoorDef RoomToWorld(const FDoorDef& RoomDoor) const;
 	FVoxelBounds WorldToRoom(const FVoxelBounds& WorldBounds) const;
 	FVoxelBounds RoomToWorld(const FVoxelBounds& RoomBounds) const;
+
+	void SetPosition(const FIntVector& NewPosition);
+	void SetDirection(EDoorDirection NewDirection);
 	void SetRotationFromDoor(int DoorIndex, EDoorDirection WorldRot);
 	void SetPositionFromDoor(int DoorIndex, FIntVector WorldPos);
 	void SetPositionAndRotationFromDoor(int DoorIndex, FIntVector WorldPos, EDoorDirection WorldRot);


### PR DESCRIPTION
## 🔍 Description
Add a new node called `Try Place Room At Location` that is an alternative to the `Try Place Room` node, which does not require a `Door Def`.
The rotation and location are based on the room's origin (its local `0,0,0` location).

## 📝 Type of Change
<!-- Check the appropriate boxes. You can replace [ ] with [x] -->
- [ ] Bug fix (`fixes` branch - patch version)
- [x] New feature (`minor` branch - minor version)
- [ ] Breaking change (`major` branch - major version)
- [ ] Documentation update

## ✅ Checklist
<!-- All the boxes must be checked -->
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] I have chosen the correct base branch (`fixes`, `minor`, or `major`)
- [x] I have rebased my feature branch onto the latest commit of the base branch
- [x] I have cleaned up my branch history (squashed/reorganized commits)
- [x] My commits are atomic (one logical change per commit)
- [x] All existing and new tests are passing
- [x] I understand that I must sign the Contributor License Agreement (CLA) before this PR can be merged

## 🔄 SemVer Impact
<!-- Describe how this change impacts semantic versioning -->
This is a **minor** change because:
- A new node is introduced.
