### PR TITLE
Feat/multi bounding box

### DIFF
--- a/Source/ProceduralDungeon/Private/DungeonGeneratorBase.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGeneratorBase.cpp
@@ -72,7 +72,6 @@ ADungeonGeneratorBase::ADungeonGeneratorBase()
 	NetDormancy = ENetDormancy::DORM_DormantAll;
 
 	Graph = CreateDefaultSubobject<UDungeonGraph>(TEXT("Dungeon Rooms"));
-	Octree = MakeUnique<FDungeonOctree>(FVector::ZeroVector, HALF_WORLD_MAX);
 }
 
 void ADungeonGeneratorBase::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
@@ -316,11 +315,7 @@ bool ADungeonGeneratorBase::TryPlaceRoomAtLocation(URoom* const& Room, FIntVecto
 bool ADungeonGeneratorBase::CheckRoomOverlap(const URoom* const& Room, const UWorld* World) const
 {
 	// Test if it fits in the place
-	bool bCanBePlaced = !URoom::Overlap(*Room, Graph->GetAllRooms());
-	// @TODO: Should be more performant to use voxel bounds instead of room bounds
-	// Also will be mandatory when RoomData will get voxel bounds editor
-	// But for now if the RoomUnit is really small (like (1,1,1)) it is really a bottle neck of performence...
-	//bool bCanBePlaced = !FVoxelBounds::Overlap(Room->GetVoxelBounds(), Graph->GetVoxelBounds());
+	bool bCanBePlaced = Graph->CanRoomFit(Room);
 
 	// Check that it does not collide with the world too
 	if (bCanBePlaced && bUseWorldCollisionChecks)
@@ -328,16 +323,19 @@ bool ADungeonGeneratorBase::CheckRoomOverlap(const URoom* const& Room, const UWo
 		if (!World)
 			World = GetWorld();
 
-		const FBoxCenterAndExtent Bounds = Room->GetBounds();
 		const FTransform& DungeonTransform = GetDungeonTransform();
-		const bool bCollideWithWorld = World->OverlapBlockingTestByChannel(
-			DungeonTransform.TransformPositionNoScale(Bounds.Center),
-			DungeonTransform.GetRotation(),
-			ECC_WorldStatic,
-			FCollisionShape::MakeBox(Bounds.Extent),
-			WorldCollisionParams
-		);
-		bCanBePlaced &= !bCollideWithWorld;
+		for (int32 i = 0; i < Room->GetSubBoundsCount() && bCanBePlaced; ++i)
+		{
+			const FBoxCenterAndExtent Bounds = Room->GetSubBounds(i);
+			const bool bCollideWithWorld = World->OverlapBlockingTestByChannel(
+				DungeonTransform.TransformPositionNoScale(Bounds.Center),
+				DungeonTransform.GetRotation(),
+				ECC_WorldStatic,
+				FCollisionShape::MakeBox(Bounds.Extent),
+				WorldCollisionParams
+			);
+			bCanBePlaced &= !bCollideWithWorld;
+		}
 	}
 
 	return bCanBePlaced;
@@ -455,10 +453,13 @@ void ADungeonGeneratorBase::UpdatePlayerRooms()
 		FPlayerRooms& PlayerRoom = PlayerRooms.FindOrAdd(PlayerID);
 		auto PreviousRoomList(PlayerRoom.CurrentRooms);
 		PlayerRoom.Roll();
-		FindElementsWithBoundsTest(*Octree, WorldPlayerBox, [this, &PlayerRoom, &PlayerID](const FDungeonOctreeElement& Element) {
-			PlayerRoom.AddCurrentRoom(Element.Room);
-			Element.Room->SetPlayerInside(PlayerID, true);
-		});
+
+		const TArray<URoom*> FoundRooms = Graph->GetAllRoomsOverlapping(WorldPlayerBox);
+		for (const auto& Room : FoundRooms)
+		{
+			PlayerRoom.AddCurrentRoom(Room);
+			Room->SetPlayerInside(PlayerID, true);
+		}
 
 		for (URoom* Room : PlayerRoom.OldRooms)
 		{
@@ -472,14 +473,14 @@ void ADungeonGeneratorBase::UpdatePlayerRooms()
 	}
 }
 
-void ADungeonGeneratorBase::UpdateRoomVisibility()
+void ADungeonGeneratorBase::UpdateRoomVisibility(bool bForceUpdate)
 {
 	const bool bIsOcclusionEnabled = Dungeon::OcclusionCulling();
 	const uint32 OcclusionDistance = Dungeon::OcclusionDistance();
-	bool bForceUpdate = false;
 
 	// Detects occlusion setting changes and toggles on/off all room visibilities when occlusion is enabled/disabled.
-	if (bWasOcclusionEnabled != bIsOcclusionEnabled
+	if (bForceUpdate
+		|| bWasOcclusionEnabled != bIsOcclusionEnabled
 		|| PreviousOcclusionDistance != OcclusionDistance)
 	{
 		bForceUpdate = true;
@@ -548,20 +549,6 @@ void ADungeonGeneratorBase::UpdateRoomRelevancy()
 void ADungeonGeneratorBase::Reset()
 {
 	PlayerRooms.Empty();
-	Octree->Destroy();
-}
-
-void ADungeonGeneratorBase::UpdateOctree()
-{
-	Octree->Destroy();
-	for (URoom* r : Graph->GetAllRooms())
-	{
-		check(IsValid(r));
-		FBoxCenterAndExtent bounds = r->GetBounds();
-		FDungeonOctreeElement octreeElement(r);
-		Octree->AddElement(octreeElement);
-		r->SetVisible(false);
-	}
 }
 
 void ADungeonGeneratorBase::UpdateSeed()
@@ -750,8 +737,8 @@ void ADungeonGeneratorBase::OnStateEnd(EGenerationState State)
 		DungeonLog_Info("======= End Dungeon Generation =======");
 		break;
 	case EGenerationState::Initialization:
+		UpdateRoomVisibility(/*bForceUpdate=*/true);
 		DungeonLog_Info("======= End Dungeon Initialization =======");
-		UpdateOctree();
 		break;
 	case EGenerationState::Load:
 		DungeonLog_Info("======= End Load All Levels =======");

--- a/Source/ProceduralDungeon/Private/DungeonGraph.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGraph.cpp
@@ -21,6 +21,12 @@
 #include "ProceduralDungeonUtils.h"
 #include "DungeonSettings.h"
 
+UDungeonGraph::UDungeonGraph()
+	: Super()
+	, Octree(FVector::ZeroVector, HALF_WORLD_MAX)
+{
+}
+
 void UDungeonGraph::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
@@ -93,6 +99,13 @@ void UDungeonGraph::PostLoadDungeon_Implementation()
 
 void UDungeonGraph::AddRoom(URoom* Room)
 {
+	check(IsValid(Room));
+
+	for (int i = 0; i < Room->GetSubBoundsCount(); ++i)
+	{
+		Octree.AddElement(FDungeonOctreeElement(Room, i));
+	}
+
 	Rooms.Add(Room);
 	UpdateBounds(Room);
 }
@@ -120,6 +133,18 @@ void UDungeonGraph::InitRooms()
 		const URoomData* Data = Room->GetRoomData();
 		Data->InitializeRoom(Room, this);
 	}
+}
+
+bool UDungeonGraph::CanRoomFit(const URoom* Room) const
+{
+	bool bCanFit = true;
+	for (int32 i = 0; i < Room->GetSubBoundsCount() && bCanFit; ++i)
+	{
+		FindElementsWithBoundsTest(Octree, Room->GetSubBounds(i), [&bCanFit, Room](const FDungeonOctreeElement& Element) {
+			bCanFit = false;
+		});
+	}
+	return bCanFit;
 }
 
 bool UDungeonGraph::TryConnectDoor(URoom* Room, int32 DoorIndex)
@@ -167,6 +192,16 @@ bool UDungeonGraph::TryConnectToExistingDoors(URoom* Room)
 		HasConnection |= TryConnectDoor(Room, i);
 	}
 	return HasConnection;
+}
+
+TArray<URoom*> UDungeonGraph::GetAllRoomsOverlapping(const FBox& Box) const
+{
+	TArray<URoom*> RoomsInBox;
+	FindElementsWithBoundsTest(Octree, Box, [&RoomsInBox](const FDungeonOctreeElement& Element) {
+		URoom* Room = Element.Room;
+		RoomsInBox.AddUnique(Room);
+	});
+	return RoomsInBox;
 }
 
 void UDungeonGraph::RetrieveRoomsFromLoadedData()
@@ -424,6 +459,7 @@ URoom* UDungeonGraph::GetRoomByIndex(int64 Index) const
 
 void UDungeonGraph::Clear()
 {
+	// Call cleanup for each room
 	for (URoom* Room : Rooms)
 	{
 		check(IsValid(Room));
@@ -431,8 +467,10 @@ void UDungeonGraph::Clear()
 		check(IsValid(Data));
 		Data->CleanupRoom(Room, this);
 	}
-	Rooms.Empty();
 
+	// Clear out data
+	Octree.Destroy();
+	Rooms.Empty();
 	RoomConnections.Empty();
 
 	RebuildBounds();

--- a/Source/ProceduralDungeon/Private/DungeonGraph.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonGraph.cpp
@@ -364,7 +364,16 @@ bool UDungeonGraph::GetPathBetween(const URoom* A, const URoom* B, TArray<URoom*
 
 URoom* UDungeonGraph::GetRoomAt(FIntVector RoomCell) const
 {
-	return URoom::GetRoomAt(RoomCell, Rooms);
+	const FVector RoomUnit = UDungeonSettings::GetRoomUnit(Generator->GetSettings());
+	FVector Location = Dungeon::ToWorldLocation(RoomCell, RoomUnit);
+	FBox LocationBox(Location, Location + FVector::OneVector);
+
+	URoom* FoundRoom = nullptr;
+	FindElementsWithBoundsTest(Octree, LocationBox, [&FoundRoom](const FDungeonOctreeElement& Element) {
+		FoundRoom = Element.Room;
+	});
+
+	return FoundRoom;
 }
 
 FVector UDungeonGraph::GetDungeonBoundsCenter() const

--- a/Source/ProceduralDungeon/Private/DungeonOctree.cpp
+++ b/Source/ProceduralDungeon/Private/DungeonOctree.cpp
@@ -1,4 +1,4 @@
-// Copyright Benoit Pelletier 2023 - 2025 All Rights Reserved.
+// Copyright Benoit Pelletier 2023 - 2026 All Rights Reserved.
 //
 // This software is available under different licenses depending on the source from which it was obtained:
 // - The Fab EULA (https://fab.com/eula) applies when obtained from the Fab marketplace.
@@ -8,8 +8,9 @@
 #include "DungeonOctree.h"
 #include "Room.h"
 
-FDungeonOctreeElement::FDungeonOctreeElement(URoom* Room)
+FDungeonOctreeElement::FDungeonOctreeElement(URoom* Room, int32 BoxIndex)
 {
+	check(IsValid(Room));
 	this->Room = Room;
-	Bounds = Room->GetBounds();
+	Bounds = Room->GetSubBounds(BoxIndex);
 }

--- a/Source/ProceduralDungeon/Private/ProceduralDungeonTypes.cpp
+++ b/Source/ProceduralDungeon/Private/ProceduralDungeonTypes.cpp
@@ -347,10 +347,22 @@ void FDoorDef::DrawDebug(const UWorld* World, const FColor& Color, const FVector
 
 // ############ FBoxMinAndMax ##############
 
+const FBoxMinAndMax FBoxMinAndMax::Invalid {FIntVector::ZeroValue, FIntVector::ZeroValue};
+
 FBoxMinAndMax::FBoxMinAndMax(const FIntVector& A, const FIntVector& B)
+{
+	SetMinAndMax(A, B);
+}
+
+void FBoxMinAndMax::SetMinAndMax(const FIntVector& A, const FIntVector& B)
 {
 	Min = IntVector::Min(A, B);
 	Max = IntVector::Max(A, B);
+}
+
+bool FBoxMinAndMax::IsValid() const
+{
+	return Max.X > Min.X && Max.Y > Min.Y && Max.Z > Min.Z;
 }
 
 FIntVector FBoxMinAndMax::GetSize() const

--- a/Source/ProceduralDungeon/Private/Room.cpp
+++ b/Source/ProceduralDungeon/Private/Room.cpp
@@ -513,9 +513,9 @@ bool URoom::IsOccupied(FIntVector Cell)
 {
 	FIntVector local = WorldToRoom(Cell);
 	FBoxMinAndMax Bounds = RoomData->GetIntBounds();
-	return local.X >= Bounds.Min.X && local.X < Bounds.Max.X
-		&& local.Y >= Bounds.Min.Y && local.Y < Bounds.Max.Y
-		&& local.Z >= Bounds.Min.Z && local.Z < Bounds.Max.Z;
+	return local.X >= Bounds.GetMin().X && local.X < Bounds.GetMax().X
+		&& local.Y >= Bounds.GetMin().Y && local.Y < Bounds.GetMax().Y
+		&& local.Z >= Bounds.GetMin().Z && local.Z < Bounds.GetMax().Z;
 }
 
 FBoxCenterAndExtent URoom::GetBounds() const

--- a/Source/ProceduralDungeon/Private/Room.cpp
+++ b/Source/ProceduralDungeon/Private/Room.cpp
@@ -1007,39 +1007,6 @@ void URoom::DispatchCallbackToSavedLevelActors(TFunction<void(AActor*)> Callback
 	}
 }
 
-// AABB Overlapping
-bool URoom::Overlap(const URoom& A, const URoom& B)
-{
-	FBoxMinAndMax BoxA = A.GetIntBounds();
-	FBoxMinAndMax BoxB = B.GetIntBounds();
-	return FBoxMinAndMax::Overlap(BoxA, BoxB);
-}
-
-bool URoom::Overlap(const URoom& Room, const TArray<URoom*>& RoomList)
-{
-	bool overlap = false;
-	for (int i = 0; i < RoomList.Num() && !overlap; i++)
-	{
-		if (Overlap(Room, *RoomList[i]))
-		{
-			overlap = true;
-		}
-	}
-	return overlap;
-}
-
-URoom* URoom::GetRoomAt(FIntVector RoomCell, const TArray<URoom*>& RoomList)
-{
-	for (URoom* Room : RoomList)
-	{
-		if (IsValid(Room) && Room->IsOccupied(RoomCell))
-		{
-			return Room;
-		}
-	}
-	return nullptr;
-}
-
 ULevelStreamingDynamic* URoom::LoadInstance(UObject* WorldContextObject, const TSoftObjectPtr<UWorld>& Level, const FString& InstanceNameSuffix, FVector Location, FRotator Rotation)
 {
 	DungeonLog_InfoSilent("[W:%s] Loading LevelStreamingDynamic", *GetNameSafe(WorldContextObject));

--- a/Source/ProceduralDungeon/Private/Room.cpp
+++ b/Source/ProceduralDungeon/Private/Room.cpp
@@ -524,6 +524,12 @@ FBoxCenterAndExtent URoom::GetBounds() const
 	return RoomData->GetBounds(GetTransform());
 }
 
+int32 URoom::GetSubBoundsCount() const
+{
+	check(IsValid(RoomData));
+	return RoomData->BoundingBoxes.Num();
+}
+
 FBoxCenterAndExtent URoom::GetLocalBounds() const
 {
 	check(IsValid(RoomData));
@@ -540,6 +546,12 @@ FVoxelBounds URoom::GetVoxelBounds() const
 {
 	check(IsValid(RoomData));
 	return RoomToWorld(RoomData->GetVoxelBounds());
+}
+
+FBoxCenterAndExtent URoom::GetSubBounds(int32 Index) const
+{
+	check(IsValid(RoomData));
+	return RoomData->GetSubBounds(Index, GetTransform());
 }
 
 FTransform URoom::GetTransform() const

--- a/Source/ProceduralDungeon/Private/RoomData.cpp
+++ b/Source/ProceduralDungeon/Private/RoomData.cpp
@@ -23,6 +23,7 @@
 URoomData::URoomData()
 	: Super()
 {
+	BoundingBoxes.Add({FIntVector(0), FIntVector(1)});
 }
 
 const FDoorDef& URoomData::GetDoorDef(int32 DoorIndex) const
@@ -153,13 +154,13 @@ FIntVector URoomData::GetSize() const
 
 int URoomData::GetVolume() const
 {
-	FIntVector Size = GetSize();
-	return Size.X * Size.Y * Size.Z;
+	const FVoxelBounds Bounds = GetVoxelBounds();
+	return Bounds.GetCellCount();
 }
 
 FBoxMinAndMax URoomData::GetIntBounds() const
 {
-	return FBoxMinAndMax(FirstPoint, SecondPoint);
+	return GetVoxelBounds().GetBounds();
 }
 
 FVoxelBounds URoomData::GetVoxelBounds() const
@@ -169,49 +170,11 @@ FVoxelBounds URoomData::GetVoxelBounds() const
 
 	// For now, just convert the IntBounds into a VoxelBounds.
 	// When the VoxelBounds editor will be implemented, we will just have to return the serialized VoxelBounds.
-	FBoxMinAndMax Bounds = GetIntBounds();
-	for (int X = Bounds.Min.X; X < Bounds.Max.X; ++X)
+	for (const FBoxMinAndMax& Box : BoundingBoxes)
 	{
-		for (int Y = Bounds.Min.Y; Y < Bounds.Max.Y; ++Y)
-		{
-			for (int Z = Bounds.Min.Z; Z < Bounds.Max.Z; ++Z)
-			{
-				CachedVoxelBounds.AddCell(FIntVector(X, Y, Z));
-			}
-		}
+		CachedVoxelBounds.AddBox(Box);
 	}
-
-	const FVoxelBoundsConnection WallConnection(EVoxelBoundsConnectionType::Wall);
-
-	// Fill top and bottom with walls.
-	for (int X = Bounds.Min.X; X < Bounds.Max.X; ++X)
-	{
-		for (int Y = Bounds.Min.Y; Y < Bounds.Max.Y; ++Y)
-		{
-			CachedVoxelBounds.SetCellConnection(FIntVector(X, Y, Bounds.Min.Z), FVoxelBounds::EDirection::Down, WallConnection);
-			CachedVoxelBounds.SetCellConnection(FIntVector(X, Y, Bounds.Max.Z - 1), FVoxelBounds::EDirection::Up, WallConnection);
-		}
-	}
-
-	// Fill left and right with walls.
-	for (int Y = Bounds.Min.Y; Y < Bounds.Max.Y; ++Y)
-	{
-		for (int Z = Bounds.Min.Z; Z < Bounds.Max.Z; ++Z)
-		{
-			CachedVoxelBounds.SetCellConnection(FIntVector(Bounds.Min.X, Y, Z), FVoxelBounds::EDirection::West, WallConnection);
-			CachedVoxelBounds.SetCellConnection(FIntVector(Bounds.Max.X - 1, Y, Z), FVoxelBounds::EDirection::East, WallConnection);
-		}
-	}
-
-	// Fill front and back with walls.
-	for (int X = Bounds.Min.X; X < Bounds.Max.X; ++X)
-	{
-		for (int Z = Bounds.Min.Z; Z < Bounds.Max.Z; ++Z)
-		{
-			CachedVoxelBounds.SetCellConnection(FIntVector(X, Bounds.Min.Y, Z), FVoxelBounds::EDirection::South, WallConnection);
-			CachedVoxelBounds.SetCellConnection(FIntVector(X, Bounds.Max.Y - 1, Z), FVoxelBounds::EDirection::North, WallConnection);
-		}
-	}
+	CachedVoxelBounds.ResetToWalls();
 
 	// Add the doors
 	for (int i = 0; i < Doors.Num(); ++i)
@@ -248,32 +211,18 @@ bool URoomData::IsDoorValid(int DoorIndex) const
 {
 	check(DoorIndex >= 0 && DoorIndex < Doors.Num());
 
+	bool bFacingNoBox = true;
+	bool bAtLeastInABox = false;
 	const FDoorDef& DoorDef = Doors[DoorIndex];
-
-	FIntVector Min = IntVector::Min(FirstPoint, SecondPoint);
-	FIntVector Max = IntVector::Max(FirstPoint, SecondPoint);
-
-	// Check if door is in the room's bounds
-	if ((DoorDef.Position.X < Min.X || DoorDef.Position.X >= Max.X)
-		|| (DoorDef.Position.Y < Min.Y || DoorDef.Position.Y >= Max.Y)
-		|| (DoorDef.Position.Z < Min.Z || DoorDef.Position.Z >= Max.Z))
-		return false;
-
-	// Check if the door is on the edge of the room bounds
-	switch (DoorDef.Direction)
+	for (const auto& Box : BoundingBoxes)
 	{
-	case EDoorDirection::South:
-		return DoorDef.Position.X == Min.X;
-	case EDoorDirection::North:
-		return DoorDef.Position.X == (Max.X - 1);
-	case EDoorDirection::West:
-		return DoorDef.Position.Y == Min.Y;
-	case EDoorDirection::East:
-		return DoorDef.Position.Y == (Max.Y - 1);
-	default:
-		checkNoEntry();
-		return false;
+		bAtLeastInABox |= Box.IsInside(DoorDef.Position);
+
+		const FIntVector FacingCell = DoorDef.Position + ToIntVector(DoorDef.Direction);
+		bFacingNoBox &= !Box.IsInside(FacingCell);
 	}
+
+	return bAtLeastInABox && bFacingNoBox;
 }
 
 bool URoomData::IsDoorDuplicate(int DoorIndex) const
@@ -285,6 +234,22 @@ bool URoomData::IsDoorDuplicate(int DoorIndex) const
 			return true;
 	}
 	return false;
+}
+
+void URoomData::DrawDebug(const UWorld* World, const FTransform& Transform, const FColor& Color)
+{
+	if (!IsValid(World))
+		return;
+
+	for (const FBoxMinAndMax& BoundingBox : BoundingBoxes)
+	{
+		FBoxCenterAndExtent Box = Dungeon::ToWorld(BoundingBox, GetRoomUnit(), Transform);
+		const FVector Center = Transform.TransformPositionNoScale(Box.Center);
+		const FVector Extent = Box.Extent;
+		const FQuat Rotation = Transform.GetRotation();
+
+		DrawDebugBox(World, Center, Extent, Rotation, Color, false, -1.0f, SDPG_World, 2.0f);
+	}
 }
 
 #endif // !(UE_BUILD_SHIPPING) || WITH_EDITOR
@@ -314,13 +279,22 @@ EDataValidationResult URoomData::IsDataValid(FDataValidationContext& Context) co
 		Result = EDataValidationResult::Invalid;
 	}
 
-	// Check if no room size is 0 on any axis
-	if (FirstPoint.X == SecondPoint.X
-		|| FirstPoint.Y == SecondPoint.Y
-		|| FirstPoint.Z == SecondPoint.Z)
+	if (BoundingBoxes.Num() <= 0)
 	{
-		VALIDATION_LOG_ERROR(FText::FromString(FString::Printf(TEXT("Room data \"%s\" has a size of 0 on at least one axis."), *GetName())));
+		VALIDATION_LOG_ERROR(FText::FromString(FString::Printf(TEXT("Room data \"%s\" should have at least one bounding box."), *GetName())));
 		Result = EDataValidationResult::Invalid;
+	}
+	else
+	{
+		// Check if all bounding boxes are valid
+		for (const FBoxMinAndMax& Box : BoundingBoxes)
+		{
+			if (!Box.IsValid())
+			{
+				VALIDATION_LOG_ERROR(FText::FromString(FString::Printf(TEXT("Room data \"%s\" has an invalid bounding box: %s."), *GetName(), *Box.ToString())));
+				Result = EDataValidationResult::Invalid;
+			}
+		}
 	}
 
 	if (Doors.Num() <= 0)

--- a/Source/ProceduralDungeon/Private/RoomData.cpp
+++ b/Source/ProceduralDungeon/Private/RoomData.cpp
@@ -11,10 +11,12 @@
 #include "ProceduralDungeonTypes.h"
 #include "ProceduralDungeonUtils.h"
 #include "ProceduralDungeonLog.h"
+#include "ProceduralDungeonCustomVersion.h"
 #include "DoorType.h"
 #include "Math/GenericOctree.h" // FBoxCenterAndExtent
 #include "DungeonSettings.h"
 #include "RoomConstraints/RoomConstraint.h"
+#include "Serialization/CustomVersion.h"
 
 #if !USE_LEGACY_DATA_VALIDATION
 	#include "Misc/DataValidation.h"
@@ -24,6 +26,33 @@ URoomData::URoomData()
 	: Super()
 {
 	BoundingBoxes.Add({FIntVector(0), FIntVector(1)});
+}
+
+void URoomData::Serialize(FArchive& Ar)
+{
+	Super::Serialize(Ar);
+
+	Ar.UsingCustomVersion(FProceduralDungeonCustomVersion::GUID);
+
+	// If loading an old version, we need to handle the migration
+	if (Ar.IsLoading())
+	{
+		const int32 DungeonVersion = Ar.CustomVer(FProceduralDungeonCustomVersion::GUID);
+		
+		if (DungeonVersion < FProceduralDungeonCustomVersion::RoomDataBoundingBoxesMigration)
+		{
+			DungeonLog_Warning("Migrating RoomData '%s' from legacy FirstPoint/SecondPoint to BoundingBoxes.", *GetName());
+
+			if (BoundingBoxes.Num() == 0)
+				BoundingBoxes.AddDefaulted();
+				
+			BoundingBoxes[0].SetMinAndMax(FirstPoint, SecondPoint);
+				
+			// Clear the legacy data after migration
+			FirstPoint = FIntVector(0);
+			SecondPoint = FIntVector(0);
+		}
+	}
 }
 
 const FDoorDef& URoomData::GetDoorDef(int32 DoorIndex) const

--- a/Source/ProceduralDungeon/Private/RoomData.cpp
+++ b/Source/ProceduralDungeon/Private/RoomData.cpp
@@ -13,7 +13,6 @@
 #include "ProceduralDungeonLog.h"
 #include "ProceduralDungeonCustomVersion.h"
 #include "DoorType.h"
-#include "Math/GenericOctree.h" // FBoxCenterAndExtent
 #include "DungeonSettings.h"
 #include "RoomConstraints/RoomConstraint.h"
 #include "Serialization/CustomVersion.h"
@@ -176,6 +175,13 @@ FBoxCenterAndExtent URoomData::GetBounds(FTransform Transform) const
 	return Dungeon::ToWorld(GetIntBounds(), GetRoomUnit(), Transform);
 }
 
+FBoxCenterAndExtent URoomData::GetSubBounds(int32 Index, FTransform Transform) const
+{
+	check(Index >= 0 && Index < BoundingBoxes.Num());
+	const FBoxMinAndMax& Box = BoundingBoxes[Index];
+	return Dungeon::ToWorld(Box, GetRoomUnit(), Transform);
+}
+
 FIntVector URoomData::GetSize() const
 {
 	return GetIntBounds().GetSize();
@@ -272,12 +278,8 @@ void URoomData::DrawDebug(const UWorld* World, const FTransform& Transform, cons
 
 	for (const FBoxMinAndMax& BoundingBox : BoundingBoxes)
 	{
-		FBoxCenterAndExtent Box = Dungeon::ToWorld(BoundingBox, GetRoomUnit(), Transform);
-		const FVector Center = Transform.TransformPositionNoScale(Box.Center);
-		const FVector Extent = Box.Extent;
-		const FQuat Rotation = Transform.GetRotation();
-
-		DrawDebugBox(World, Center, Extent, Rotation, Color, false, -1.0f, SDPG_World, 2.0f);
+		const FBoxCenterAndExtent Box = Dungeon::ToWorld(BoundingBox, GetRoomUnit(), Transform);
+		DrawDebugBox(World, Box.Center, Box.Extent, FQuat::Identity, Color, false, -1.0f, SDPG_World, 2.0f);
 	}
 }
 

--- a/Source/ProceduralDungeon/Private/RoomLevel.cpp
+++ b/Source/ProceduralDungeon/Private/RoomLevel.cpp
@@ -151,7 +151,9 @@ void ARoomLevel::Tick(float DeltaTime)
 			DrawDebugSphere(World, DungeonTransform.TransformPositionNoScale(RoomTransform.GetLocation()), 100.0f, 4, FColor::Magenta);
 
 		// Room bounds
-		DrawDebugBox(World, GetBoundsCenter(), GetBoundsExtent(), DungeonTransform.GetRotation(), IsPlayerInside() ? FColor::Green : FColor::Red);
+		DrawDebugBox(World, GetBoundsCenter(), GetBoundsExtent(), DungeonTransform.GetRotation(), FColor::Yellow);
+
+		Data->DrawDebug(World, RoomTransform * DungeonTransform, IsPlayerInside() ? FColor::Green : FColor::Red);
 
 		if (bIsRoomLocked)
 		{

--- a/Source/ProceduralDungeon/Private/RoomLevel.cpp
+++ b/Source/ProceduralDungeon/Private/RoomLevel.cpp
@@ -151,8 +151,6 @@ void ARoomLevel::Tick(float DeltaTime)
 			DrawDebugSphere(World, DungeonTransform.TransformPositionNoScale(RoomTransform.GetLocation()), 100.0f, 4, FColor::Magenta);
 
 		// Room bounds
-		DrawDebugBox(World, GetBoundsCenter(), GetBoundsExtent(), DungeonTransform.GetRotation(), FColor::Yellow);
-
 		Data->DrawDebug(World, RoomTransform * DungeonTransform, IsPlayerInside() ? FColor::Green : FColor::Red);
 
 		if (bIsRoomLocked)

--- a/Source/ProceduralDungeon/Private/Tests/BoxMinAndMaxTests.cpp
+++ b/Source/ProceduralDungeon/Private/Tests/BoxMinAndMaxTests.cpp
@@ -20,21 +20,26 @@ bool FBoxMinAndMaxTest::RunTest(const FString& Parameters)
 	// Constructor Test
 	{
 		FBoxMinAndMax Box0;
-		FBoxMinAndMax Box1(FIntVector(0), FIntVector(1));
+		FBoxMinAndMax Box1(FIntVector(-1), FIntVector(1));
 		FBoxMinAndMax Box2(FIntVector(3, 2, 1), FIntVector(-1, -2, -3));
 		FBoxMinAndMax Box3(Box2);
 		FBoxMinAndMax Box4(FIntVector(-3, 2, -1), FIntVector(1, -2, 3));
+		FBoxMinAndMax Box5 = FBoxMinAndMax::Invalid;
 
-		TestEqual(TEXT("Default Constructor Min == 0"), Box0.Min, FIntVector(0));
-		TestEqual(TEXT("Default Constructor Max == 0"), Box0.Max, FIntVector(0));
-		TestEqual(TEXT("Constructor (0,1) Min == 0"), Box1.Min, FIntVector(0));
-		TestEqual(TEXT("Constructor (0,1) Max == 1"), Box1.Max, FIntVector(1));
-		TestEqual(TEXT("Constructor ((3,2,1), (-1,-2,-3)) Min == (-1,-2,-3)"), Box2.Min, FIntVector(-1, -2, -3));
-		TestEqual(TEXT("Constructor ((3,2,1), (-1,-2,-3)) Max == (3,2,1)"), Box2.Max, FIntVector(3, 2, 1));
-		TestEqual(TEXT("Copy Constructor of ((3,2,1), (-1,-2,-3)) Min == (-1,-2,-3)"), Box3.Min, FIntVector(-1, -2, -3));
-		TestEqual(TEXT("Copy Constructor of ((3,2,1), (-1,-2,-3)) Max == (3,2,1)"), Box3.Max, FIntVector(3, 2, 1));
-		TestEqual(TEXT("Constructor ((-3,2,-1), (1,-2,3)) Min == (-3,-2,-1)"), Box4.Min, FIntVector(-3, -2, -1));
-		TestEqual(TEXT("Constructor ((-3,2,-1), (1,-2,3)) Max == (1,2,3)"), Box4.Max, FIntVector(1, 2, 3));
+		TestEqual(TEXT("Default Constructor Min == 0"), Box0.GetMin(), FIntVector(0));
+		TestEqual(TEXT("Default Constructor Max == 1"), Box0.GetMax(), FIntVector(1));
+		TestEqual(TEXT("Constructor (-1,1) Min == -1"), Box1.GetMin(), FIntVector(-1));
+		TestEqual(TEXT("Constructor (-1,1) Max == 1"), Box1.GetMax(), FIntVector(1));
+		TestEqual(TEXT("Constructor ((3,2,1), (-1,-2,-3)) Min == (-1,-2,-3)"), Box2.GetMin(), FIntVector(-1, -2, -3));
+		TestEqual(TEXT("Constructor ((3,2,1), (-1,-2,-3)) Max == (3,2,1)"), Box2.GetMax(), FIntVector(3, 2, 1));
+		TestEqual(TEXT("Copy Constructor of ((3,2,1), (-1,-2,-3)) Min == (-1,-2,-3)"), Box3.GetMin(), FIntVector(-1, -2, -3));
+		TestEqual(TEXT("Copy Constructor of ((3,2,1), (-1,-2,-3)) Max == (3,2,1)"), Box3.GetMax(), FIntVector(3, 2, 1));
+		TestEqual(TEXT("Constructor ((-3,2,-1), (1,-2,3)) Min == (-3,-2,-1)"), Box4.GetMin(), FIntVector(-3, -2, -1));
+		TestEqual(TEXT("Constructor ((-3,2,-1), (1,-2,3)) Max == (1,2,3)"), Box4.GetMax(), FIntVector(1, 2, 3));
+
+		TestEqual(TEXT("Invalid Box Max == 0"), Box5.GetMin(), FIntVector(0));
+		TestEqual(TEXT("Invalid Box Max == 0"), Box5.GetMax(), FIntVector(0));
+		TestFalse(TEXT("Invalid Box is not Valid"), Box5.IsValid());
 	}
 
 	// Size Test
@@ -89,14 +94,14 @@ bool FBoxMinAndMaxTest::RunTest(const FString& Parameters)
 		FBoxMinAndMax RotBox0S = Rotate(Box0, EDoorDirection::South);
 		FBoxMinAndMax RotBox0W = Rotate(Box0, EDoorDirection::West);
 
-		TestEqual(TEXT("Rotate(Box(0,1), N).Min == 0"), RotBox0N.Min, FIntVector(0));
-		TestEqual(TEXT("Rotate(Box(0,1), N).Max == 1"), RotBox0N.Max, FIntVector(1));
-		TestEqual(TEXT("Rotate(Box(0,1), E).Min == 0"), RotBox0E.Min, FIntVector(0));
-		TestEqual(TEXT("Rotate(Box(0,1), E).Max == 1"), RotBox0E.Max, FIntVector(1));
-		TestEqual(TEXT("Rotate(Box(0,1), S).Min == 0"), RotBox0S.Min, FIntVector(0));
-		TestEqual(TEXT("Rotate(Box(0,1), S).Max == 1"), RotBox0S.Max, FIntVector(1));
-		TestEqual(TEXT("Rotate(Box(0,1), W).Min == 0"), RotBox0W.Min, FIntVector(0));
-		TestEqual(TEXT("Rotate(Box(0,1), W).Max == 1"), RotBox0W.Max, FIntVector(1));
+		TestEqual(TEXT("Rotate(Box(0,1), N).Min == 0"), RotBox0N.GetMin(), FIntVector(0));
+		TestEqual(TEXT("Rotate(Box(0,1), N).Max == 1"), RotBox0N.GetMax(), FIntVector(1));
+		TestEqual(TEXT("Rotate(Box(0,1), E).Min == 0"), RotBox0E.GetMin(), FIntVector(0));
+		TestEqual(TEXT("Rotate(Box(0,1), E).Max == 1"), RotBox0E.GetMax(), FIntVector(1));
+		TestEqual(TEXT("Rotate(Box(0,1), S).Min == 0"), RotBox0S.GetMin(), FIntVector(0));
+		TestEqual(TEXT("Rotate(Box(0,1), S).Max == 1"), RotBox0S.GetMax(), FIntVector(1));
+		TestEqual(TEXT("Rotate(Box(0,1), W).Min == 0"), RotBox0W.GetMin(), FIntVector(0));
+		TestEqual(TEXT("Rotate(Box(0,1), W).Max == 1"), RotBox0W.GetMax(), FIntVector(1));
 
 		FBoxMinAndMax Box1(FIntVector(-1, 0, -1), FIntVector(3, 1, 1));
 		FBoxMinAndMax RotBox1N = Rotate(Box1, EDoorDirection::North);
@@ -104,14 +109,14 @@ bool FBoxMinAndMaxTest::RunTest(const FString& Parameters)
 		FBoxMinAndMax RotBox1S = Rotate(Box1, EDoorDirection::South);
 		FBoxMinAndMax RotBox1W = Rotate(Box1, EDoorDirection::West);
 
-		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), N).Min == (-1,0,-1)"), RotBox1N.Min, FIntVector(-1, 0, -1));
-		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), N).Max == (3,1,1)"), RotBox1N.Max, FIntVector(3, 1, 1));
-		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), E).Min == (0,-1,-1)"), RotBox1E.Min, FIntVector(0, -1, -1));
-		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), E).Max == (1,3,1)"), RotBox1E.Max, FIntVector(1, 3, 1));
-		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), S).Min == (-2,0,-1)"), RotBox1S.Min, FIntVector(-2, 0, -1));
-		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), S).Max == (2,1,1)"), RotBox1S.Max, FIntVector(2, 1, 1));
-		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), W).Min == (0,-2,-1)"), RotBox1W.Min, FIntVector(0, -2, -1));
-		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), W).Max == (1,2,1)"), RotBox1W.Max, FIntVector(1, 2, 1));
+		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), N).Min == (-1,0,-1)"), RotBox1N.GetMin(), FIntVector(-1, 0, -1));
+		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), N).Max == (3,1,1)"), RotBox1N.GetMax(), FIntVector(3, 1, 1));
+		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), E).Min == (0,-1,-1)"), RotBox1E.GetMin(), FIntVector(0, -1, -1));
+		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), E).Max == (1,3,1)"), RotBox1E.GetMax(), FIntVector(1, 3, 1));
+		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), S).Min == (-2,0,-1)"), RotBox1S.GetMin(), FIntVector(-2, 0, -1));
+		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), S).Max == (2,1,1)"), RotBox1S.GetMax(), FIntVector(2, 1, 1));
+		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), W).Min == (0,-2,-1)"), RotBox1W.GetMin(), FIntVector(0, -2, -1));
+		TestEqual(TEXT("Rotate(Box((-1,0,-1), (3,1,1)), W).Max == (1,2,1)"), RotBox1W.GetMax(), FIntVector(1, 2, 1));
 	}
 
 	// Extend Test

--- a/Source/ProceduralDungeon/Private/Tests/DungeonGraphTests.cpp
+++ b/Source/ProceduralDungeon/Private/Tests/DungeonGraphTests.cpp
@@ -40,6 +40,7 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FDungeonGraphTest, "ProceduralDungeon.Types.Dun
 		Path.Empty();        \
 		Path.Add(nullptr);
 
+#pragma optimize("", off)
 bool FDungeonGraphTest::RunTest(const FString& Parameters)
 {
 	{
@@ -59,7 +60,7 @@ bool FDungeonGraphTest::RunTest(const FString& Parameters)
 		DA_C->Doors.Add({{0, 0, 0}, EDoorDirection::East});
 		DA_C->Doors.Add({{0, 0, 0}, EDoorDirection::West});
 
-		DA_D->SecondPoint = {1, 1, 2};
+		DA_D->BoundingBoxes[0].SetMinAndMax({0, 0, 0}, {1, 1, 2});
 		DA_D->Doors.Add({{0, 0, 0}, EDoorDirection::North});
 		DA_D->Doors.Add({{0, 0, 1}, EDoorDirection::North});
 
@@ -303,13 +304,13 @@ bool FDungeonGraphTest::RunTest(const FString& Parameters)
 			CREATE_DATA_ASSET(UConstraintFail, Fail);
 
 			CREATE_ROOM_DATA(DA_E);
-			DA_E->SecondPoint = {1, 2, 1};
+			DA_E->BoundingBoxes[0].SetMinAndMax({0, 0, 0}, {1, 2, 1});
 			DA_E->Doors.Add({{0, 1, 0}, EDoorDirection::North});
 			DA_E->Constraints.Add(Pass.Get());
 
 			// Same as DA_E but constraint fail
 			CREATE_ROOM_DATA(DA_F);
-			DA_F->SecondPoint = {1, 2, 1};
+			DA_F->BoundingBoxes[0].SetMinAndMax({0, 0, 0}, {1, 2, 1});
 			DA_F->Doors.Add({{0, 1, 0}, EDoorDirection::North});
 			DA_F->Constraints.Add(Fail.Get());
 
@@ -372,6 +373,7 @@ bool FDungeonGraphTest::RunTest(const FString& Parameters)
 
 	return true;
 }
+	#pragma optimize("", on)
 
 	#undef INIT_TEST
 	#undef CLEAN_TEST

--- a/Source/ProceduralDungeon/Private/Tests/RoomDataTests.cpp
+++ b/Source/ProceduralDungeon/Private/Tests/RoomDataTests.cpp
@@ -48,8 +48,7 @@ bool FRoomDataTests::RunTest(const FString& Parameters)
 		//	   -2 +---+-v-+---+
 		//		 -1   0   1   2
 		CREATE_ROOM_DATA(RoomData);
-		RoomData->FirstPoint = FIntVector(-2, -1, -1);
-		RoomData->SecondPoint = FIntVector(1, 2, 2);
+		RoomData->BoundingBoxes[0].SetMinAndMax(FIntVector(-2, -1, -1), FIntVector(1, 2, 2));
 
 		FDoorDef Door;
 		Door.Position = FIntVector(-2, 0, 0);
@@ -198,8 +197,6 @@ bool FRoomDataTests::RunTest(const FString& Parameters)
 	// Test HasDoorOfType and variants
 	{
 		CREATE_ROOM_DATA(RoomData);
-		RoomData->FirstPoint = FIntVector(0, 0, 0);
-		RoomData->SecondPoint = FIntVector(1, 1, 1);
 
 		CREATE_DATA_ASSET(UDoorType, DoorA);
 		CREATE_DATA_ASSET(UDoorType, DoorB);
@@ -242,8 +239,6 @@ bool FRoomDataTests::RunTest(const FString& Parameters)
 	// Test HasCustomData and variants
 	{
 		CREATE_ROOM_DATA(RoomData);
-		RoomData->FirstPoint = FIntVector(0, 0, 0);
-		RoomData->SecondPoint = FIntVector(1, 1, 1);
 
 		RoomData->CustomData.Add(UCustomDataA::StaticClass());
 		RoomData->CustomData.Add(UCustomDataB::StaticClass());
@@ -277,23 +272,19 @@ bool FRoomDataTests::RunTest(const FString& Parameters)
 	{
 		// Should have Size=(1,1,1) and Volume=1
 		CREATE_ROOM_DATA(RoomDataA);
-		RoomDataA->FirstPoint = FIntVector(0, 1, 0);
-		RoomDataA->SecondPoint = FIntVector(1, 0, 1);
+		RoomDataA->BoundingBoxes[0].SetMinAndMax(FIntVector(0, 1, 0), FIntVector(1, 0, 1));
 
 		// Should have Size=(2,1,1) and Volume=2
 		CREATE_ROOM_DATA(RoomDataB);
-		RoomDataB->FirstPoint = FIntVector(-1, 1, 0);
-		RoomDataB->SecondPoint = FIntVector(1, 0, 1);
+		RoomDataB->BoundingBoxes[0].SetMinAndMax(FIntVector(-1, 1, 0), FIntVector(1, 0, 1));
 
 		// Should have Size=(2,2,1) and Volume=4
 		CREATE_ROOM_DATA(RoomDataC);
-		RoomDataC->FirstPoint = FIntVector(-1, 1, 0);
-		RoomDataC->SecondPoint = FIntVector(1, -1, 1);
+		RoomDataC->BoundingBoxes[0].SetMinAndMax(FIntVector(-1, 1, 0), FIntVector(1, -1, 1));
 
 		// Should have Size=(2,2,2) and Volume=8
 		CREATE_ROOM_DATA(RoomDataD);
-		RoomDataD->FirstPoint = FIntVector(-1, 1, -1);
-		RoomDataD->SecondPoint = FIntVector(1, -1, 1);
+		RoomDataD->BoundingBoxes[0].SetMinAndMax(FIntVector(-1, 1, -1), FIntVector(1, -1, 1));
 
 		// GetSize
 		{
@@ -315,8 +306,6 @@ bool FRoomDataTests::RunTest(const FString& Parameters)
 	// Test GetVoxelBounds
 	{
 		CREATE_ROOM_DATA(RoomDataA);
-		RoomDataA->FirstPoint = FIntVector(0, 0, 0);
-		RoomDataA->SecondPoint = FIntVector(1, 1, 1);
 		RoomDataA->Doors.Add({{0, 0, 0}, EDoorDirection::North});
 
 		// Should have one cell at (0,0,0) with a door at (0,0,0)[North]
@@ -336,32 +325,31 @@ bool FRoomDataTests::RunTest(const FString& Parameters)
 		}
 
 		CREATE_ROOM_DATA(RoomDataB);
-		RoomDataB->FirstPoint = FIntVector(-1, 0, 0);
-		RoomDataB->SecondPoint = FIntVector(2, 1, 1);
-		RoomDataB->Doors.Add({{0, 0, 0}, EDoorDirection::South});
-		RoomDataB->Doors.Add({{1, 0, 0}, EDoorDirection::East});
+		RoomDataB->BoundingBoxes[0].SetMinAndMax(FIntVector(-1, 0, 0), FIntVector(2, 1, 1));
+		RoomDataB->Doors.Add({{0, 0, 0}, EDoorDirection::West});
+		RoomDataB->Doors.Add({{1, 0, 0}, EDoorDirection::North});
 
-		// Should have 3 cells at (-1,0,0), (0,0,0), (1,0,0) with doors at (0,0,0)[South] and (1,0,0)[East]
+		// Should have 3 cells at (-1,0,0), (0,0,0), (1,0,0) with doors at (0,0,0)[West] and (1,0,0)[North]
 		{
 			FVoxelBounds ExpectedBounds;
 			ExpectedBounds.AddCell({-1, 0, 0});
 			ExpectedBounds.AddCell({0, 0, 0});
 			ExpectedBounds.AddCell({1, 0, 0});
 
-			ExpectedBounds.SetCellConnection({-1, 0, 0}, FVoxelBounds::EDirection::North, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
+			ExpectedBounds.SetCellConnection({-1, 0, 0}, FVoxelBounds::EDirection::East, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 			ExpectedBounds.SetCellConnection({-1, 0, 0}, FVoxelBounds::EDirection::West, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 			ExpectedBounds.SetCellConnection({-1, 0, 0}, FVoxelBounds::EDirection::South, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 			ExpectedBounds.SetCellConnection({-1, 0, 0}, FVoxelBounds::EDirection::Up, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 			ExpectedBounds.SetCellConnection({-1, 0, 0}, FVoxelBounds::EDirection::Down, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 
-			ExpectedBounds.SetCellConnection({0, 0, 0}, FVoxelBounds::EDirection::North, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
-			ExpectedBounds.SetCellConnection({0, 0, 0}, FVoxelBounds::EDirection::South, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Door));
+			ExpectedBounds.SetCellConnection({0, 0, 0}, FVoxelBounds::EDirection::East, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
+			ExpectedBounds.SetCellConnection({0, 0, 0}, FVoxelBounds::EDirection::West, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Door));
 			ExpectedBounds.SetCellConnection({0, 0, 0}, FVoxelBounds::EDirection::Up, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 			ExpectedBounds.SetCellConnection({0, 0, 0}, FVoxelBounds::EDirection::Down, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 
-			ExpectedBounds.SetCellConnection({1, 0, 0}, FVoxelBounds::EDirection::North, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
-			ExpectedBounds.SetCellConnection({1, 0, 0}, FVoxelBounds::EDirection::South, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
-			ExpectedBounds.SetCellConnection({1, 0, 0}, FVoxelBounds::EDirection::East, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Door));
+			ExpectedBounds.SetCellConnection({1, 0, 0}, FVoxelBounds::EDirection::North, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Door));
+			ExpectedBounds.SetCellConnection({1, 0, 0}, FVoxelBounds::EDirection::East, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
+			ExpectedBounds.SetCellConnection({1, 0, 0}, FVoxelBounds::EDirection::West, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 			ExpectedBounds.SetCellConnection({1, 0, 0}, FVoxelBounds::EDirection::Up, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 			ExpectedBounds.SetCellConnection({1, 0, 0}, FVoxelBounds::EDirection::Down, FVoxelBoundsConnection(EVoxelBoundsConnectionType::Wall));
 
@@ -370,8 +358,7 @@ bool FRoomDataTests::RunTest(const FString& Parameters)
 		}
 
 		CREATE_ROOM_DATA(RoomDataC);
-		RoomDataC->FirstPoint = FIntVector(0, 0, -1);
-		RoomDataC->SecondPoint = FIntVector(1, 1, 2);
+		RoomDataC->BoundingBoxes[0].SetMinAndMax(FIntVector(0, 0, -1), FIntVector(1, 1, 2));
 		RoomDataC->Doors.Add({{0, 0, 0}, EDoorDirection::North});
 		RoomDataC->Doors.Add({{0, 0, 1}, EDoorDirection::South});
 

--- a/Source/ProceduralDungeon/Private/Tests/VoxelBoundsTests.cpp
+++ b/Source/ProceduralDungeon/Private/Tests/VoxelBoundsTests.cpp
@@ -35,7 +35,7 @@ bool FVoxelBoundsTest::RunTest(const FString& Parameters)
 
 		TestEqual(TEXT("BoundsA == ({0, -1, 0}, {2, 2, 3})"), BoundsA.GetBounds(), FBoxMinAndMax({0, -1, 0}, {2, 2, 3}));
 		TestEqual(TEXT("BoundsB == ({1, 1, 1}, {2, 2, 2})"), BoundsB.GetBounds(), FBoxMinAndMax({1, 1, 1}, {2, 2, 2}));
-		TestEqual(TEXT("BoundsC == ({0, 0, 0}, {0, 0, 0})"), BoundsC.GetBounds(), FBoxMinAndMax());
+		TestEqual(TEXT("BoundsC == ({0, 0, 0}, {0, 0, 0})"), BoundsC.GetBounds(), FBoxMinAndMax::Invalid);
 	}
 
 	// Comparison Test

--- a/Source/ProceduralDungeon/Private/VoxelBounds/VoxelBounds.cpp
+++ b/Source/ProceduralDungeon/Private/VoxelBounds/VoxelBounds.cpp
@@ -81,6 +81,24 @@ TArray<FVoxelBoundsConnection>& FVoxelBounds::AddCell(FIntVector Cell)
 	return Connections;
 }
 
+void FVoxelBounds::AddBox(const FBoxMinAndMax& Box)
+{
+	Bounds.Extend(Box);
+	Cells.Reserve(Cells.Num() + Box.GetSize().X * Box.GetSize().Y * Box.GetSize().Z);
+
+	for (int32 X = Box.GetMin().X; X < Box.GetMax().X; ++X)
+	{
+		for (int32 Y = Box.GetMin().Y; Y < Box.GetMax().Y; ++Y)
+		{
+			for (int32 Z = Box.GetMin().Z; Z < Box.GetMax().Z; ++Z)
+			{
+				auto& Connections = Cells.Add(FIntVector(X, Y, Z));
+				Connections.SetNum(static_cast<uint8>(EDirection::NbDirection));
+			}
+		}
+	}
+}
+
 const FVoxelBoundsConnection* FVoxelBounds::GetCellConnection(FIntVector Cell, EDirection Direction) const
 {
 	auto* CellConnections = Cells.Find(Cell);
@@ -99,6 +117,22 @@ bool FVoxelBounds::SetCellConnection(FIntVector Cell, EDirection Direction, cons
 	return true;
 }
 
+void FVoxelBounds::ResetToWalls()
+{
+	static const FVoxelBoundsConnection NoneConnection(EVoxelBoundsConnectionType::None);
+	static const FVoxelBoundsConnection WallConnection(EVoxelBoundsConnectionType::Wall);
+
+	for (auto& Cell : Cells)
+	{
+		for (uint8 i = 0; i < static_cast<uint8>(EDirection::NbDirection); ++i)
+		{
+			const FIntVector OtherCell = Cell.Key + Directions[i];
+			const auto* FoundOtherCell = Cells.Find(OtherCell);
+			Cell.Value[i] = (FoundOtherCell) ? NoneConnection : WallConnection;
+		}
+	}
+}
+
 bool FVoxelBounds::GetCompatibilityScore(const FVoxelBounds& Other, int32& Score, const FScoreCallback& CustomScore) const
 {
 	// Each cell add 1 to the score, so the bigger volume the higher score.
@@ -108,12 +142,12 @@ bool FVoxelBounds::GetCompatibilityScore(const FVoxelBounds& Other, int32& Score
 
 	// @TODO: for now, treating a coincident face as overlapping
 	// There is room for further optimizations here later
-	bAreOverlapping |= Bounds.Min.X == Other.Bounds.Max.X;
-	bAreOverlapping |= Bounds.Max.X == Other.Bounds.Min.X;
-	bAreOverlapping |= Bounds.Min.Y == Other.Bounds.Max.Y;
-	bAreOverlapping |= Bounds.Max.Y == Other.Bounds.Min.Y;
-	bAreOverlapping |= Bounds.Min.Z == Other.Bounds.Max.Z;
-	bAreOverlapping |= Bounds.Max.Z == Other.Bounds.Min.Z;
+	bAreOverlapping |= Bounds.GetMin().X == Other.Bounds.GetMax().X;
+	bAreOverlapping |= Bounds.GetMax().X == Other.Bounds.GetMin().X;
+	bAreOverlapping |= Bounds.GetMin().Y == Other.Bounds.GetMax().Y;
+	bAreOverlapping |= Bounds.GetMax().Y == Other.Bounds.GetMin().Y;
+	bAreOverlapping |= Bounds.GetMin().Z == Other.Bounds.GetMax().Z;
+	bAreOverlapping |= Bounds.GetMax().Z == Other.Bounds.GetMin().Z;
 
 	// When not overlapping, the score is equal to the number of cell
 	// and it does always fit outside too.

--- a/Source/ProceduralDungeon/Public/DungeonGeneratorBase.h
+++ b/Source/ProceduralDungeon/Public/DungeonGeneratorBase.h
@@ -347,6 +347,7 @@ public:
 	FVector GetDungeonOffset() const;
 	FQuat GetDungeonRotation() const;
 	const FTransform& GetDungeonTransform() const;
+	const UDungeonSettings* GetSettings() const { return SettingsOverrides; }
 
 	FORCEINLINE const UDungeonGraph* GetRooms() const { return Graph; }
 	FORCEINLINE EGenerationState GetCurrentState() const { return CurrentState; }

--- a/Source/ProceduralDungeon/Public/DungeonGeneratorBase.h
+++ b/Source/ProceduralDungeon/Public/DungeonGeneratorBase.h
@@ -10,7 +10,6 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "Math/RandomStream.h"
-#include "DungeonOctree.h"
 #include "ProceduralDungeonTypes.h"
 #include "CollisionQueryParams.h"
 #include "UObject/ScriptInterface.h"
@@ -285,16 +284,13 @@ private:
 	void UpdatePlayerRooms();
 
 	// Update the rooms visibility based on the player position
-	void UpdateRoomVisibility();
+	void UpdateRoomVisibility(bool bForceUpdate = false);
 
 	// Update the rooms relevancy based on the player position
 	void UpdateRoomRelevancy();
 
 	// Reset all data from a specific generation
 	void Reset();
-
-	// Clear and refill octree from the dungeon graph
-	void UpdateOctree();
 
 	// Initialize the seed depending on the seed type setting
 	void UpdateSeed();
@@ -419,7 +415,6 @@ private:
 	};
 
 	// Occlusion culling system
-	TUniquePtr<FDungeonOctree> Octree;
 	TMap<int32, FPlayerRooms> PlayerRooms;
 
 	// Transient. Only used to detect when occlusion setting is changed.

--- a/Source/ProceduralDungeon/Public/DungeonGraph.h
+++ b/Source/ProceduralDungeon/Public/DungeonGraph.h
@@ -1,4 +1,4 @@
-// Copyright Benoit Pelletier 2023 - 2025 All Rights Reserved.
+// Copyright Benoit Pelletier 2023 - 2026 All Rights Reserved.
 //
 // This software is available under different licenses depending on the source from which it was obtained:
 // - The Fab EULA (https://fab.com/eula) applies when obtained from the Fab marketplace.
@@ -16,6 +16,7 @@
 #include "Templates/Function.h"
 #include "ProceduralDungeonTypes.h"
 #include "VoxelBounds/VoxelBounds.h"
+#include "DungeonOctree.h"
 #include "DungeonGraph.generated.h"
 
 class URoom;
@@ -38,6 +39,8 @@ class PROCEDURALDUNGEON_API UDungeonGraph : public UReplicableObject, public IRo
 #endif
 
 public:
+	UDungeonGraph();
+
 	//~ Begin IRoomContainer Interface
 	// Returns the room instance with the provided index.
 	// Returns null if no room exists with the provided index.
@@ -63,8 +66,11 @@ public:
 	void InitRooms();
 	void Clear();
 
+	bool CanRoomFit(const URoom* Room) const;
 	bool TryConnectDoor(URoom* Room, int32 DoorIndex);
 	bool TryConnectToExistingDoors(URoom* Room);
+
+	TArray<URoom*> GetAllRoomsOverlapping(const FBox& Box) const;
 
 	bool HasRooms() const { return Rooms.Num() > 0; }
 	bool IsDirty() const { return bIsDirty; }
@@ -255,6 +261,9 @@ private:
 
 	// Transient. The computed bounds of the dungeon. Updated each time the room list changes.
 	FVoxelBounds Bounds;
+
+	// Transient, used for room collision checks.
+	FDungeonOctree Octree;
 
 private:
 	struct FSaveData

--- a/Source/ProceduralDungeon/Public/DungeonOctree.h
+++ b/Source/ProceduralDungeon/Public/DungeonOctree.h
@@ -1,4 +1,4 @@
-// Copyright Benoit Pelletier 2023 - 2025 All Rights Reserved.
+// Copyright Benoit Pelletier 2023 - 2026 All Rights Reserved.
 //
 // This software is available under different licenses depending on the source from which it was obtained:
 // - The Fab EULA (https://fab.com/eula) applies when obtained from the Fab marketplace.
@@ -20,8 +20,9 @@ struct FDungeonOctreeElement
 {
 	class URoom* Room;
 	FBoxCenterAndExtent Bounds;
+	int32 Index;
 
-	FDungeonOctreeElement(URoom* Room);
+	FDungeonOctreeElement(URoom* Room, int32 BoxIndex);
 };
 
 struct FDungeonOctreeSemantics
@@ -39,7 +40,7 @@ struct FDungeonOctreeSemantics
 
 	FORCEINLINE static bool AreElementsEqual(const FDungeonOctreeElement& A, const FDungeonOctreeElement& B)
 	{
-		return A.Room == B.Room;
+		return A.Room == B.Room && A.Index == B.Index;
 	}
 
 	FORCEINLINE static void SetElementId(const FDungeonOctreeElement& Element

--- a/Source/ProceduralDungeon/Public/ProceduralDungeonCustomVersion.h
+++ b/Source/ProceduralDungeon/Public/ProceduralDungeonCustomVersion.h
@@ -18,6 +18,7 @@ struct FProceduralDungeonCustomVersion
 		// Before any version changes were made
 		InitialVersion = 0,
 		SoftObjectPtrFix, // Fixed issues with SoftObjectPtr replication in Room.h
+		RoomDataBoundingBoxesMigration, // Migrated FirstPoint/SecondPoint to BoundingBoxes in RoomData.h
 
 		// -----<new versions can be added above this line>-------------------------------------------------
 		VersionPlusOne,

--- a/Source/ProceduralDungeon/Public/ProceduralDungeonTypes.h
+++ b/Source/ProceduralDungeon/Public/ProceduralDungeonTypes.h
@@ -155,16 +155,27 @@ public:
 // The downside of doing that would be the Center and Extent computation that is slightly different...
 // Also, the IsInside with another box does not consider coincident faces as inside...
 // Also, operators + and += don't mean the same (extending box to include a point instead of shifting the box)...
+USTRUCT(BlueprintType)
 struct PROCEDURALDUNGEON_API FBoxMinAndMax
 {
-public:
+	GENERATED_BODY();
+
+protected:
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Box")
 	FIntVector Min {0};
-	FIntVector Max {0};
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Box")
+	FIntVector Max {1};
 
 public:
 	FBoxMinAndMax() = default;
 	FBoxMinAndMax(const FIntVector& A, const FIntVector& B);
 
+	void SetMinAndMax(const FIntVector& A, const FIntVector& B);
+	FIntVector GetMin() const { return Min; }
+	FIntVector GetMax() const { return Max; }
+
+	bool IsValid() const;
 	FIntVector GetSize() const;
 	FBoxCenterAndExtent ToCenterAndExtent() const;
 	bool IsInside(const FIntVector& Cell) const;
@@ -182,6 +193,9 @@ public:
 	FBoxMinAndMax operator-(const FIntVector& X) const;
 	bool operator==(const FBoxMinAndMax& Other) const;
 	bool operator!=(const FBoxMinAndMax& Other) const;
+
+public:
+	static const FBoxMinAndMax Invalid;
 };
 
 FBoxMinAndMax PROCEDURALDUNGEON_API Rotate(const FBoxMinAndMax& Box, const EDoorDirection& Rot);

--- a/Source/ProceduralDungeon/Public/Room.h
+++ b/Source/ProceduralDungeon/Public/Room.h
@@ -305,12 +305,6 @@ public:
 	FBoxMinAndMax GetIntBounds() const;
 	FVoxelBounds GetVoxelBounds() const;
 
-	// AABB Overlapping
-	static bool Overlap(const URoom& A, const URoom& B);
-	static bool Overlap(const URoom& Room, const TArray<URoom*>& RoomList);
-
-	static URoom* GetRoomAt(FIntVector RoomCell, const TArray<URoom*>& RoomList);
-
 private:
 	// Utility functions to load/unload level instances
 	static ULevelStreamingDynamic* LoadInstance(UObject* WorldContextObject, const TSoftObjectPtr<UWorld>& Level, const FString& InstanceNameSuffix, FVector Location, FRotator Rotation);

--- a/Source/ProceduralDungeon/Public/Room.h
+++ b/Source/ProceduralDungeon/Public/Room.h
@@ -299,6 +299,8 @@ public:
 
 	FTransform GetTransform() const;
 	FBoxCenterAndExtent GetBounds() const;
+	int32 GetSubBoundsCount() const;
+	FBoxCenterAndExtent GetSubBounds(int32 Index) const;
 	FBoxCenterAndExtent GetLocalBounds() const;
 	FBoxMinAndMax GetIntBounds() const;
 	FVoxelBounds GetVoxelBounds() const;

--- a/Source/ProceduralDungeon/Public/RoomData.h
+++ b/Source/ProceduralDungeon/Public/RoomData.h
@@ -11,6 +11,7 @@
 #include "Engine/DataAsset.h"
 #include "ProceduralDungeonTypes.h"
 #include "Misc/EngineVersionComparison.h"
+#include "Math/GenericOctree.h" // for FBoxCenterAndExtent (required for UE5.0)
 #include "VoxelBounds/VoxelBounds.h"
 #include "RoomData.generated.h"
 
@@ -125,7 +126,8 @@ public:
 	UFUNCTION(BlueprintPure, Category = "Room Contraint")
 	static bool DoesPassAllConstraints(const UDungeonGraph* Dungeon, const URoomData* RoomData, FIntVector Location, EDoorDirection Direction);
 
-	class FBoxCenterAndExtent GetBounds(FTransform Transform = FTransform::Identity) const;
+	FBoxCenterAndExtent GetBounds(FTransform Transform = FTransform::Identity) const;
+	FBoxCenterAndExtent GetSubBounds(int32 Index, FTransform Transform = FTransform::Identity) const;
 	FBoxMinAndMax GetIntBounds() const;
 	FVoxelBounds GetVoxelBounds() const;
 

--- a/Source/ProceduralDungeon/Public/RoomData.h
+++ b/Source/ProceduralDungeon/Public/RoomData.h
@@ -51,10 +51,10 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Doors")
 	TArray<FDoorDef> Doors {FDoorDef()};
 
-	UPROPERTY(VisibleAnywhere, Category = "Room")
+	UPROPERTY(meta = (DeprecatedProperty, DeprecationMessage = "Use BoundingBoxes instead"))
 	FIntVector FirstPoint {0};
 
-	UPROPERTY(VisibleAnywhere, Category = "Room")
+	UPROPERTY(meta = (DeprecatedProperty, DeprecationMessage = "Use BoundingBoxes instead"))
 	FIntVector SecondPoint {1};
 
 	UPROPERTY(EditAnywhere, Category = "Room")
@@ -71,6 +71,8 @@ public:
 
 public:
 	URoomData();
+
+	virtual void Serialize(FArchive& Ar) override;
 
 	UFUNCTION(BlueprintPure, Category = "Room Data", meta = (DisplayName = "Door Count", CompactNodeTitle = "Door Count"))
 	int GetNbDoor() const { return Doors.Num(); }

--- a/Source/ProceduralDungeon/Public/RoomData.h
+++ b/Source/ProceduralDungeon/Public/RoomData.h
@@ -43,7 +43,6 @@ public:
 	UPROPERTY(EditInstanceOnly, Category = "Level")
 	TSoftObjectPtr<UWorld> Level {nullptr};
 
-public:
 	// This will force a random door to be chosen during the dungeon generation.
 	// DEPRECATED: It will be removed in a future version of the plugin. As a replacement, you should return -1 as DoorIndex in the ChooseNextRoomData of your DungeonGenerator.
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Doors")
@@ -52,11 +51,14 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Doors")
 	TArray<FDoorDef> Doors {FDoorDef()};
 
-	UPROPERTY(EditAnywhere, Category = "Room")
+	UPROPERTY(VisibleAnywhere, Category = "Room")
 	FIntVector FirstPoint {0};
 
-	UPROPERTY(EditAnywhere, Category = "Room")
+	UPROPERTY(VisibleAnywhere, Category = "Room")
 	FIntVector SecondPoint {1};
+
+	UPROPERTY(EditAnywhere, Category = "Room")
+	TArray<FBoxMinAndMax> BoundingBoxes;
 
 	UPROPERTY(EditDefaultsOnly, Category = "Room")
 	TSet<TSubclassOf<URoomCustomData>> CustomData;
@@ -130,6 +132,7 @@ public:
 #if !(UE_BUILD_SHIPPING) || WITH_EDITOR
 	bool IsDoorValid(int DoorIndex) const;
 	bool IsDoorDuplicate(int DoorIndex) const;
+	void DrawDebug(const UWorld* World, const FTransform& Transform, const FColor& Color);
 #endif // !(UE_BUILD_SHIPPING) || WITH_EDITOR
 
 #if WITH_EDITOR

--- a/Source/ProceduralDungeon/Public/VoxelBounds/VoxelBounds.h
+++ b/Source/ProceduralDungeon/Public/VoxelBounds/VoxelBounds.h
@@ -73,10 +73,14 @@ public:
 	static EDirection Opposite(EDirection Direction);
 
 	TArray<FVoxelBoundsConnection>& AddCell(FIntVector Cell);
+	void AddBox(const FBoxMinAndMax& Box);
 
 	const FVoxelBoundsConnection* GetCellConnection(FIntVector Cell, EDirection Direction) const;
 	bool SetCellConnection(FIntVector Cell, EDirection Direction, const FVoxelBoundsConnection& Connection);
 
+	void ResetToWalls();
+
+	int32 GetCellCount() const { return Cells.Num(); }
 	const FBoxMinAndMax& GetBounds() const { return Bounds; }
 	bool IsValid() const { return Cells.Num() > 0; }
 
@@ -107,5 +111,5 @@ public:
 
 private:
 	TMap<FIntVector, TArray<FVoxelBoundsConnection>> Cells;
-	FBoxMinAndMax Bounds;
+	FBoxMinAndMax Bounds {FBoxMinAndMax::Invalid};
 };

--- a/Source/ProceduralDungeonEditor/Private/EditorMode/SProceduralDungeonEdModeWidget.cpp
+++ b/Source/ProceduralDungeonEditor/Private/EditorMode/SProceduralDungeonEdModeWidget.cpp
@@ -340,7 +340,18 @@ void SProceduralDungeonEdModeWidget::OnDataAssetChanged()
 			CachedData->Level = EdMode->GetWorld();
 			DungeonEd_LogInfo("Room Data's Level asset filled with current editor's Level.");
 		}
-		DataDelegateHandle = CachedData->OnPropertiesChanged.AddLambda([this](URoomData* Data) { UpdateErrorText(); });
+		DataDelegateHandle = CachedData->OnPropertiesChanged.AddLambda([this](URoomData* Data)
+		{
+			UpdateErrorText();
+
+			auto EdMode = GetEditorMode();
+			if (EdMode)
+			{
+				FProceduralDungeonEditorTool* ActiveTool = EdMode->GetActiveTool();
+				if (ActiveTool)
+					ActiveTool->OnDataPropertiesChanged(CachedData.Get());
+			}
+		});
 	}
 
 	UpdateErrorText();

--- a/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool.h
+++ b/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool.h
@@ -52,6 +52,7 @@ public:
 
 	virtual void OnLevelChanged(const class ARoomLevel* NewLevel) {}
 	virtual void OnDataChanged(const class URoomData* NewData) {}
+	virtual void OnDataPropertiesChanged(const class URoomData* Data) {}
 
 	class URoomData* GetRoomData() const;
 

--- a/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool_Door.cpp
+++ b/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool_Door.cpp
@@ -57,14 +57,84 @@ bool IsDoorValid(const URoomData* Data, const FDoorDef& Door)
 void FProceduralDungeonEditorTool_Door::EnterTool()
 {
 	DungeonEd_LogInfo("Enter Door Tool.");
-	UpdateRoomBox();
+	UpdateCollision();
 }
 
 void FProceduralDungeonEditorTool_Door::ExitTool()
 {
 	DungeonEd_LogInfo("Exit Door Tool.");
-	DestroyRoomBox();
+	DestroyCollision();
 	CachedLevel.Reset();
+}
+
+namespace
+{
+	void RenderBoundingBox(FPrimitiveDrawInterface* PDI, const FBoxCenterAndExtent& Box, const FColor& Color)
+	{
+		const FVector Center = Box.Center;
+		const FVector Extent = Box.Extent;
+		const FVector A = Center + FVector(Extent.X, Extent.Y, Extent.Z);
+		const FVector B = Center + FVector(Extent.X, Extent.Y, -Extent.Z);
+		const FVector C = Center + FVector(Extent.X, -Extent.Y, Extent.Z);
+		const FVector D = Center + FVector(Extent.X, -Extent.Y, -Extent.Z);
+		const FVector E = Center + FVector(-Extent.X, Extent.Y, Extent.Z);
+		const FVector F = Center + FVector(-Extent.X, Extent.Y, -Extent.Z);
+		const FVector G = Center + FVector(-Extent.X, -Extent.Y, Extent.Z);
+		const FVector H = Center + FVector(-Extent.X, -Extent.Y, -Extent.Z);
+		PDI->DrawLine(A, B, Color, SDPG_Foreground);
+		PDI->DrawLine(A, C, Color, SDPG_Foreground);
+		PDI->DrawLine(A, E, Color, SDPG_Foreground);
+		PDI->DrawLine(B, D, Color, SDPG_Foreground);
+		PDI->DrawLine(B, F, Color, SDPG_Foreground);
+		PDI->DrawLine(C, D, Color, SDPG_Foreground);
+		PDI->DrawLine(C, G, Color, SDPG_Foreground);
+		PDI->DrawLine(D, H, Color, SDPG_Foreground);
+		PDI->DrawLine(E, F, Color, SDPG_Foreground);
+		PDI->DrawLine(E, G, Color, SDPG_Foreground);
+		PDI->DrawLine(F, H, Color, SDPG_Foreground);
+		PDI->DrawLine(G, H, Color, SDPG_Foreground);
+	}
+
+	void RenderInterlinesBoundingBox(FPrimitiveDrawInterface* PDI, const FBoxMinAndMax& Box, const FColor& Color, const FVector& RoomUnit)
+	{
+		FIntVector Min, Max;
+		IntVector::MinMax(Box.GetMin(), Box.GetMax(), Min, Max);
+
+		// Vertical Lines on X
+		for (int32 i = Min.X + 1; i < Max.X; ++i)
+		{
+			FIntVector BottomA(i, Min.Y, Min.Z);
+			FIntVector BottomB(i, Max.Y, Min.Z);
+			FIntVector TopA(i, Min.Y, Max.Z);
+			FIntVector TopB(i, Max.Y, Max.Z);
+			PDI->DrawLine(Dungeon::ToWorldLocation(BottomA, RoomUnit), Dungeon::ToWorldLocation(TopA, RoomUnit), Color, SDPG_World);
+			PDI->DrawLine(Dungeon::ToWorldLocation(BottomB, RoomUnit), Dungeon::ToWorldLocation(TopB, RoomUnit), Color, SDPG_World);
+		}
+
+		// Vertical Lines on Y
+		for (int32 i = Min.Y + 1; i < Max.Y; ++i)
+		{
+			FIntVector BottomA(Min.X, i, Min.Z);
+			FIntVector BottomB(Max.X, i, Min.Z);
+			FIntVector TopA(Min.X, i, Max.Z);
+			FIntVector TopB(Max.X, i, Max.Z);
+			PDI->DrawLine(Dungeon::ToWorldLocation(BottomA, RoomUnit), Dungeon::ToWorldLocation(TopA, RoomUnit), Color, SDPG_World);
+			PDI->DrawLine(Dungeon::ToWorldLocation(BottomB, RoomUnit), Dungeon::ToWorldLocation(TopB, RoomUnit), Color, SDPG_World);
+		}
+
+		// Horizontal Lines on X and Y
+		for (int32 i = Min.Z + 1; i < Max.Z; ++i)
+		{
+			FIntVector A(Min.X, Min.Y, i);
+			FIntVector B(Min.X, Max.Y, i);
+			FIntVector C(Max.X, Max.Y, i);
+			FIntVector D(Max.X, Min.Y, i);
+			PDI->DrawLine(Dungeon::ToWorldLocation(A, RoomUnit), Dungeon::ToWorldLocation(B, RoomUnit), Color, SDPG_World);
+			PDI->DrawLine(Dungeon::ToWorldLocation(B, RoomUnit), Dungeon::ToWorldLocation(C, RoomUnit), Color, SDPG_World);
+			PDI->DrawLine(Dungeon::ToWorldLocation(C, RoomUnit), Dungeon::ToWorldLocation(D, RoomUnit), Color, SDPG_World);
+			PDI->DrawLine(Dungeon::ToWorldLocation(D, RoomUnit), Dungeon::ToWorldLocation(A, RoomUnit), Color, SDPG_World);
+		}
+	}
 }
 
 void FProceduralDungeonEditorTool_Door::Render(const FSceneView* View, FViewport* Viewport, FPrimitiveDrawInterface* PDI)
@@ -75,45 +145,12 @@ void FProceduralDungeonEditorTool_Door::Render(const FSceneView* View, FViewport
 	if (!IsValid(Data))
 		return;
 
-	FIntVector Min, Max;
-	IntVector::MinMax(Data->FirstPoint, Data->SecondPoint, Min, Max);
-
 	const FColor LineColor(100, 20, 0);
 	const FVector RoomUnit = Data->GetRoomUnit();
 
-	// Vertical Lines on X
-	for (int32 i = Min.X + 1; i < Max.X; ++i)
+	for (const auto& BoundingBox : Data->BoundingBoxes)
 	{
-		FIntVector BottomA(i, Min.Y, Min.Z);
-		FIntVector BottomB(i, Max.Y, Min.Z);
-		FIntVector TopA(i, Min.Y, Max.Z);
-		FIntVector TopB(i, Max.Y, Max.Z);
-		PDI->DrawLine(Dungeon::ToWorldLocation(BottomA, RoomUnit), Dungeon::ToWorldLocation(TopA, RoomUnit), LineColor, SDPG_World);
-		PDI->DrawLine(Dungeon::ToWorldLocation(BottomB, RoomUnit), Dungeon::ToWorldLocation(TopB, RoomUnit), LineColor, SDPG_World);
-	}
-
-	// Vertical Lines on Y
-	for (int32 i = Min.Y + 1; i < Max.Y; ++i)
-	{
-		FIntVector BottomA(Min.X, i, Min.Z);
-		FIntVector BottomB(Max.X, i, Min.Z);
-		FIntVector TopA(Min.X, i, Max.Z);
-		FIntVector TopB(Max.X, i, Max.Z);
-		PDI->DrawLine(Dungeon::ToWorldLocation(BottomA, RoomUnit), Dungeon::ToWorldLocation(TopA, RoomUnit), LineColor, SDPG_World);
-		PDI->DrawLine(Dungeon::ToWorldLocation(BottomB, RoomUnit), Dungeon::ToWorldLocation(TopB, RoomUnit), LineColor, SDPG_World);
-	}
-
-	// Horizontal Lines on X and Y
-	for (int32 i = Min.Z + 1; i < Max.Z; ++i)
-	{
-		FIntVector A(Min.X, Min.Y, i);
-		FIntVector B(Min.X, Max.Y, i);
-		FIntVector C(Max.X, Max.Y, i);
-		FIntVector D(Max.X, Min.Y, i);
-		PDI->DrawLine(Dungeon::ToWorldLocation(A, RoomUnit), Dungeon::ToWorldLocation(B, RoomUnit), LineColor, SDPG_World);
-		PDI->DrawLine(Dungeon::ToWorldLocation(B, RoomUnit), Dungeon::ToWorldLocation(C, RoomUnit), LineColor, SDPG_World);
-		PDI->DrawLine(Dungeon::ToWorldLocation(C, RoomUnit), Dungeon::ToWorldLocation(D, RoomUnit), LineColor, SDPG_World);
-		PDI->DrawLine(Dungeon::ToWorldLocation(D, RoomUnit), Dungeon::ToWorldLocation(A, RoomUnit), LineColor, SDPG_World);
+		RenderInterlinesBoundingBox(PDI, BoundingBox, LineColor, RoomUnit);
 	}
 }
 
@@ -222,54 +259,103 @@ bool FProceduralDungeonEditorTool_Door::GetCursor(EMouseCursor::Type& OutCursor)
 
 void FProceduralDungeonEditorTool_Door::OnLevelChanged(const ARoomLevel* NewLevel)
 {
-	UpdateRoomBox();
+	UpdateCollision();
 }
 
 void FProceduralDungeonEditorTool_Door::OnDataChanged(const URoomData* NewData)
 {
-	UpdateRoomBox();
+	UpdateCollision();
 }
 
-void FProceduralDungeonEditorTool_Door::UpdateRoomBox()
+void FProceduralDungeonEditorTool_Door::OnDataPropertiesChanged(const URoomData* Data)
+{
+	UpdateCollision();
+}
+
+void FProceduralDungeonEditorTool_Door::CreateCollision(ARoomLevel* Level)
+{
+	if (!IsValid(Level))
+		return;
+
+	if (!IsValid(Level->Data))
+		return;
+
+	check(IsValid(Level->GetWorld()));
+
+	const int32 NumBoxes = Level->Data->BoundingBoxes.Num();
+	const int32 Delta = NumBoxes - RoomBoxes.Num();
+
+	// Create new boxes when delta is positive
+	for (int i = 0; i < Delta; ++i)
+	{
+		FName BoxName = FName(*FString::Printf(TEXT("Editor Room Collision %d"), RoomBoxes.Num()));
+		UBoxComponent* RoomBox = NewObject<UBoxComponent>(Level, BoxName, RF_Transient);
+		check(IsValid(RoomBox));
+		RoomBox->SetupAttachment(Level->GetRootComponent());
+		RoomBox->RegisterComponent();
+		RoomBox->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Ignore);
+		RoomBox->SetCollisionObjectType(ECollisionChannel::ECC_MAX);
+		RoomBoxes.Add(RoomBox);
+		DungeonEd_LogInfo("Created RoomBox: %s", *GetNameSafe(RoomBox));
+	}
+
+	// Destroy boxes when delta is negative
+	for (int i = 0; i > Delta; --i)
+	{
+		if (RoomBoxes.Num() == 0)
+			break;
+		TWeakObjectPtr<UBoxComponent> RoomBox = RoomBoxes.Pop();
+		if (!RoomBox.IsValid())
+			continue;
+		RoomBox->DestroyComponent();
+		DungeonEd_LogInfo("Destroyed RoomBox: %s", *GetNameSafe(RoomBox.Get()));
+	}
+}
+
+void FProceduralDungeonEditorTool_Door::UpdateCollision()
 {
 	auto Level = EdMode->GetLevelInstance();
 	if (Level != CachedLevel)
 	{
+		DestroyCollision();
 		CachedLevel = Level;
-
-		DestroyRoomBox();
-		if (CachedLevel.IsValid())
-		{
-			check(IsValid(Level->GetWorld()));
-			RoomBox = NewObject<UBoxComponent>(CachedLevel.Get(), TEXT("Editor Room Collision"), RF_Transient);
-			RoomBox->SetupAttachment(CachedLevel->GetRootComponent());
-			RoomBox->RegisterComponent();
-			RoomBox->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Ignore);
-			RoomBox->SetCollisionObjectType(ECollisionChannel::ECC_MAX);
-			DungeonEd_LogInfo("Create RoomBox: %s", *GetNameSafe(RoomBox.Get()));
-		}
 	}
+
 
 	if (!CachedLevel.IsValid())
 		return;
 
-	if (!IsValid(CachedLevel->Data))
+	URoomData* Data = CachedLevel->Data;
+	if (!IsValid(Data))
 		return;
 
-	FBoxCenterAndExtent Box = CachedLevel->Data->GetBounds();
-	RoomBox->SetRelativeLocation(Box.Center);
-	RoomBox->SetBoxExtent(Box.Extent);
+	CreateCollision(CachedLevel.Get());
+	check(Data->BoundingBoxes.Num() == RoomBoxes.Num());
 
-	DungeonEd_LogInfo("Update RoomBox: %s", *GetNameSafe(RoomBox.Get()));
+	for (int i = 0; i < Data->BoundingBoxes.Num(); ++i)
+	{
+		const FBoxMinAndMax& DataBox = Data->BoundingBoxes[i];
+		UBoxComponent* RoomBox = RoomBoxes[i].Get();
+
+		FBoxCenterAndExtent Box = Dungeon::ToWorld(DataBox, Data->GetRoomUnit());
+		RoomBox->SetRelativeLocation(Box.Center);
+		RoomBox->SetBoxExtent(Box.Extent);
+
+		DungeonEd_LogInfo("Updated RoomBox: %s", *GetNameSafe(RoomBox));
+	}
 }
 
-void FProceduralDungeonEditorTool_Door::DestroyRoomBox()
+void FProceduralDungeonEditorTool_Door::DestroyCollision()
 {
-	if (RoomBox.IsValid())
+	for (const auto& RoomBox : RoomBoxes)
 	{
+		if (!RoomBox.IsValid())
+			continue;
+
 		RoomBox->DestroyComponent();
-		RoomBox.Reset();
 	}
+
+	RoomBoxes.Empty();
 }
 
 bool FProceduralDungeonEditorTool_Door::RoomTraceFromMouse(FHitResult& OutHit, FEditorViewportClient* ViewportClient) const
@@ -298,10 +384,26 @@ bool FProceduralDungeonEditorTool_Door::RoomTraceFromMouse(FHitResult& OutHit, F
 
 bool FProceduralDungeonEditorTool_Door::RoomTrace(FHitResult& OutHit, const FVector& RayOrigin, const FVector& RayEnd) const
 {
-	if (!RoomBox.IsValid())
-		return false;
+	OutHit = FHitResult();
+	FHitResult Hit;
+	bool bHasHit = false;
+	for (const auto& RoomBox : RoomBoxes)
+	{
+		if (!RoomBox.IsValid())
+			continue;
 
-	return RoomBox->LineTraceComponent(OutHit, RayOrigin, RayEnd, FCollisionQueryParams(SCENE_QUERY_STAT(RoomTrace)));
+		const bool bSuccess = RoomBox->LineTraceComponent(Hit, RayOrigin, RayEnd, FCollisionQueryParams(SCENE_QUERY_STAT(RoomTrace)));
+		if (!bSuccess)
+			continue;
+
+		if (!bHasHit || Hit.Distance < OutHit.Distance)
+		{
+			OutHit = Hit;
+			bHasHit = true;
+		}
+	}
+
+	return bHasHit;
 }
 
 bool FProceduralDungeonEditorTool_Door::GetRoomCellFromHit(const FHitResult& Hit, const FVector RoomUnit, FIntVector& OutCell, EDoorDirection& OutDirection) const

--- a/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool_Door.h
+++ b/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool_Door.h
@@ -9,6 +9,8 @@
 
 #include "ProceduralDungeonEditorTool.h"
 
+class ARoomLevel;
+
 class FProceduralDungeonEditorTool_Door : public FProceduralDungeonEditorTool
 {
 public:
@@ -30,20 +32,22 @@ public:
 	virtual bool MouseMove(FEditorViewportClient* ViewportClient, FViewport* Viewport, int32 MouseX, int32 MouseY) override;
 	virtual bool GetCursor(EMouseCursor::Type& OutCursor) const override;
 
-	virtual void OnLevelChanged(const class ARoomLevel* NewLevel) override;
-	virtual void OnDataChanged(const URoomData* NewData = nullptr) override;
+	virtual void OnLevelChanged(const ARoomLevel* NewLevel) override;
+	virtual void OnDataChanged(const URoomData* NewData) override;
+	virtual void OnDataPropertiesChanged(const URoomData* Data) override;
 	//~ End FProceduralDungeonEditorTool Interface
 
 protected:
-	void UpdateRoomBox();
-	void DestroyRoomBox();
+	void CreateCollision(ARoomLevel* level);
+	void UpdateCollision();
+	void DestroyCollision();
 	bool RoomTraceFromMouse(FHitResult& OutHit, FEditorViewportClient* ViewportClient) const;
 	bool RoomTrace(FHitResult& OutHit, const FVector& RayOrigin, const FVector& RayEnd) const;
 	bool GetRoomCellFromHit(const FHitResult& Hit, const FVector RoomUnit, FIntVector& OutCell, EDoorDirection& OutDirection) const;
 
 private:
-	TWeakObjectPtr<class ARoomLevel> CachedLevel = nullptr;
-	TWeakObjectPtr<class UBoxComponent> RoomBox = nullptr;
+	TWeakObjectPtr<ARoomLevel> CachedLevel = nullptr;
+	TArray<TWeakObjectPtr<class UBoxComponent>> RoomBoxes;
 	FDoorDef DoorPreview;
 	bool ShowDoorPreview {false};
 };

--- a/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool_Size.cpp
+++ b/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool_Size.cpp
@@ -91,31 +91,6 @@ void FRoomPoint::UpdateFrom(FRoomPoint& From, EAxisList::Type Axis)
 
 void FProceduralDungeonEditorTool_Size::EnterTool()
 {
-	//        6    1
-	//      2    7
-	//        4    5
-	//      0    3
-
-	Points.Empty();
-	Points.AddDefaulted(8);
-
-	Points[0].AddLinkedPoint(Points[2], EAxisList::XY);
-	Points[0].AddLinkedPoint(Points[3], EAxisList::XZ);
-	Points[0].AddLinkedPoint(Points[4], EAxisList::YZ);
-
-	Points[1].AddLinkedPoint(Points[5], EAxisList::XY);
-	Points[1].AddLinkedPoint(Points[6], EAxisList::XZ);
-	Points[1].AddLinkedPoint(Points[7], EAxisList::YZ);
-
-	Points[2].AddLinkedPoint(Points[6], EAxisList::YZ);
-	Points[2].AddLinkedPoint(Points[7], EAxisList::XZ);
-
-	Points[3].AddLinkedPoint(Points[5], EAxisList::YZ);
-	Points[3].AddLinkedPoint(Points[7], EAxisList::XY);
-
-	Points[4].AddLinkedPoint(Points[5], EAxisList::XZ);
-	Points[4].AddLinkedPoint(Points[6], EAxisList::XY);
-
 	OnDataChanged();
 	ResetSelectedPoint();
 }
@@ -127,21 +102,13 @@ void FProceduralDungeonEditorTool_Size::ExitTool()
 
 void FProceduralDungeonEditorTool_Size::Render(const FSceneView* View, FViewport* Viewport, FPrimitiveDrawInterface* PDI)
 {
-	const FColor NormalColor(200, 200, 200);
-	const FColor SelectedColor(255, 128, 0);
-
 	const URoomData* Data = GetRoomData();
 	if (!IsValid(Data))
 		return;
 
-	for (int i = 0; i < Points.Num(); ++i)
+	for (const FBoxPoints& Box : Boxes)
 	{
-		const bool bSelected = (SelectedPoint == i);
-		const FColor& Color = bSelected ? SelectedColor : NormalColor;
-
-		PDI->SetHitProxy(new HRoomPointProxy(i));
-		PDI->DrawPoint(Points[i].GetLocation(), Color, 15.0f, SDPG_Foreground);
-		PDI->SetHitProxy(nullptr);
+		Box.Draw(PDI, SelectedPoint);
 	}
 }
 
@@ -156,7 +123,7 @@ bool FProceduralDungeonEditorTool_Size::HandleClick(FEditorViewportClient* InVie
 		return false;
 
 	const HRoomPointProxy* RoomProxy = (HRoomPointProxy*)HitProxy;
-	checkf(RoomProxy->Index >= 0 && RoomProxy->Index < Points.Num(), TEXT("A room point has been clicked but is out of bounds!"));
+	checkf(RoomProxy->Index >= 0 && RoomProxy->Index < GetMaxIndex(), TEXT("A room point has been clicked but is out of bounds!"));
 
 	SetSelectedPoint(RoomProxy->Index);
 	GEditor->GetSelectedActors()->DeselectAll();
@@ -191,10 +158,11 @@ bool FProceduralDungeonEditorTool_Size::InputDelta(FEditorViewportClient* InView
 	if (!InDrag.IsNearlyZero())
 	{
 		DragPoint += InDrag;
-		FVector OldPoint = Points[SelectedPoint].GetLocation();
-		Points[SelectedPoint].SetLocation(Dungeon::SnapPoint(DragPoint, Data->GetRoomUnit()));
-		if (OldPoint != Points[SelectedPoint].GetLocation())
-			UpdateDataAsset();
+		FRoomPoint& Point = GetSelectedPoint();
+		FVector OldPoint = Point.GetLocation();
+		Point.SetLocation(Dungeon::SnapPoint(DragPoint, Data->GetRoomUnit()));
+		if (OldPoint != Point.GetLocation())
+			UpdateDataAsset(GetBoxIndexFromPointIndex(SelectedPoint));
 	}
 	return true;
 }
@@ -226,41 +194,53 @@ void FProceduralDungeonEditorTool_Size::PostRedo(bool bSuccess)
 
 void FProceduralDungeonEditorTool_Size::OnDataChanged(const URoomData* NewData)
 {
-	const URoomData* Data = GetRoomData();
-	if (!IsValid(Data))
-		return;
-
-	Points[0].SetLocation(Dungeon::ToWorldLocation(Data->FirstPoint, Data->GetRoomUnit()));
-	Points[1].SetLocation(Dungeon::ToWorldLocation(Data->SecondPoint, Data->GetRoomUnit()));
-
+	// When the room data has changed, reset all
+	ResetSelectedPoint();
 	ResetDragPoint();
+
+	UpdateBoxes(NewData);
+}
+
+void FProceduralDungeonEditorTool_Size::OnDataPropertiesChanged(const URoomData* Data)
+{
+	UpdateBoxes(Data);
 }
 
 bool FProceduralDungeonEditorTool_Size::HasValidSelection() const
 {
-	return SelectedPoint >= 0 && SelectedPoint < Points.Num();
+	return SelectedPoint >= 0 && SelectedPoint < GetMaxIndex();
 }
 
 void FProceduralDungeonEditorTool_Size::ResetDragPoint()
 {
 	if (HasValidSelection())
-		DragPoint = Points[SelectedPoint].GetLocation();
+		DragPoint = GetSelectedPoint().GetLocation();
+	else
+		DragPoint = FVector::ZeroVector;
 }
 
-void FProceduralDungeonEditorTool_Size::UpdateDataAsset() const
+void FProceduralDungeonEditorTool_Size::UpdateDataAsset(int32 BoxIndex) const
 {
 	URoomData* Data = GetRoomData();
 	if (!IsValid(Data))
 		return;
 
-	Data->Modify();
-	Data->FirstPoint = Dungeon::ToRoomLocation(Points[0].GetLocation(), Data->GetRoomUnit());
-	Data->SecondPoint = Dungeon::ToRoomLocation(Points[1].GetLocation(), Data->GetRoomUnit());
+	if (BoxIndex >= 0 && BoxIndex < Data->BoundingBoxes.Num())
+	{
+		Data->Modify();
+		const FVector RoomUnit = Data->GetRoomUnit();
+		const FBoxPoints& Box = Boxes[BoxIndex];
+		FBoxMinAndMax& DataBox = Data->BoundingBoxes[BoxIndex];
+		const FIntVector A = Dungeon::ToRoomLocation(Box.GetMin(), RoomUnit);
+		const FIntVector B = Dungeon::ToRoomLocation(Box.GetMax(), RoomUnit);
+		DataBox.SetMinAndMax(A, B);
+		return;
+	}
 }
 
 void FProceduralDungeonEditorTool_Size::SetSelectedPoint(int32 Index)
 {
-	if (Index < 0 || Index >= Points.Num())
+	if (Index < 0 || Index >= GetMaxIndex())
 		Index = -1;
 
 	DungeonEd_LogInfo("Selected Point: %d", Index);
@@ -271,4 +251,87 @@ void FProceduralDungeonEditorTool_Size::SetSelectedPoint(int32 Index)
 void FProceduralDungeonEditorTool_Size::ResetSelectedPoint()
 {
 	SetSelectedPoint(-1);
+}
+
+FRoomPoint& FProceduralDungeonEditorTool_Size::GetSelectedPoint()
+{
+	checkf(HasValidSelection(), TEXT("Trying to get selected point but selection is invalid!"));
+	const int32 BoxIndex = GetBoxIndexFromPointIndex(SelectedPoint);
+	const int32 PointIndex = GetBoxPointIndex(SelectedPoint);
+	checkf(BoxIndex >= 0 && BoxIndex < Boxes.Num(), TEXT("Selected point's box index is out of bounds!"));
+	checkf(PointIndex >= 0 && PointIndex < FBoxPoints::NbPoints, TEXT("Selected point's point index is out of bounds!"));
+	return Boxes[BoxIndex].GetPoint(PointIndex);
+}
+
+void FProceduralDungeonEditorTool_Size::UpdateBoxes(const URoomData* Data)
+{
+	if (!IsValid(Data))
+		return;
+
+	const int32 NbBoxes = Data->BoundingBoxes.Num();
+	if (Boxes.Num() != NbBoxes)
+	{
+		Boxes.SetNum(NbBoxes);
+	}
+
+	const FVector RoomUnit = Data->GetRoomUnit();
+	for (int32 i = 0; i < NbBoxes; ++i)
+	{
+		const FBoxMinAndMax& Box = Data->BoundingBoxes[i];
+		Boxes[i].SetID(i);
+		Boxes[i].SetMin(Dungeon::ToWorldLocation(Box.GetMin(), RoomUnit));
+		Boxes[i].SetMax(Dungeon::ToWorldLocation(Box.GetMax(), RoomUnit));
+	}
+}
+
+FBoxPoints::FBoxPoints()
+{
+	//        6    1
+	//      2    7
+	//        4    5
+	//      0    3
+
+	Points[0].AddLinkedPoint(Points[2], EAxisList::XY);
+	Points[0].AddLinkedPoint(Points[3], EAxisList::XZ);
+	Points[0].AddLinkedPoint(Points[4], EAxisList::YZ);
+
+	Points[1].AddLinkedPoint(Points[5], EAxisList::XY);
+	Points[1].AddLinkedPoint(Points[6], EAxisList::XZ);
+	Points[1].AddLinkedPoint(Points[7], EAxisList::YZ);
+
+	Points[2].AddLinkedPoint(Points[6], EAxisList::YZ);
+	Points[2].AddLinkedPoint(Points[7], EAxisList::XZ);
+
+	Points[3].AddLinkedPoint(Points[5], EAxisList::YZ);
+	Points[3].AddLinkedPoint(Points[7], EAxisList::XY);
+
+	Points[4].AddLinkedPoint(Points[5], EAxisList::XZ);
+	Points[4].AddLinkedPoint(Points[6], EAxisList::XY);
+}
+
+void FBoxPoints::SetMin(FVector Value)
+{
+	Points[0].SetLocation(Value);
+}
+
+void FBoxPoints::SetMax(FVector Value)
+{
+	Points[1].SetLocation(Value);
+}
+
+void FBoxPoints::Draw(FPrimitiveDrawInterface* PDI, int32 SelectedPoint) const
+{
+	static const FColor NormalColor(200, 200, 200);
+	static const FColor SelectedColor(255, 128, 0);
+
+	const int32 LocalSelectedIndex = SelectedPoint - (ID * NbPoints);
+	for (int i = 0; i < NbPoints; ++i)
+	{
+		const bool bSelected = (LocalSelectedIndex == i);
+		const FColor& Color = bSelected ? SelectedColor : NormalColor;
+
+		PDI->SetHitProxy(new HRoomPointProxy(ID * NbPoints + i));
+		PDI->DrawPoint(Points[i].GetLocation(), Color, 10.0f, SDPG_Foreground);
+		PDI->SetHitProxy(nullptr);
+	}
 }

--- a/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool_Size.h
+++ b/Source/ProceduralDungeonEditor/Private/EditorMode/Tools/ProceduralDungeonEditorTool_Size.h
@@ -48,6 +48,33 @@ private:
 	TArray<FLink> LinkedPoints {};
 };
 
+struct FBoxPoints
+{
+public:
+	FBoxPoints();
+
+	void SetID(uint32 InID) { ID = InID; }
+	void SetMin(FVector Value);
+	void SetMax(FVector Value);
+	uint32 GetID() const { return ID; }
+	FVector GetMin() const { return Points[0].GetLocation(); }
+	FVector GetMax() const { return Points[1].GetLocation(); }
+
+	FRoomPoint& GetPoint(int32 Index)
+	{
+		check(Index >= 0 && Index < NbPoints);
+		return Points[Index];
+	}
+
+	void Draw(FPrimitiveDrawInterface* PDI, int32 SelectedPoint) const;
+
+	static const uint32 NbPoints {8};
+
+private:
+	uint32 ID;
+	FRoomPoint Points[NbPoints];
+};
+
 class FProceduralDungeonEditorTool_Size : public FProceduralDungeonEditorTool
 {
 public:
@@ -76,16 +103,24 @@ public:
 	virtual void PostRedo(bool bSuccess) override;
 
 	virtual void OnDataChanged(const URoomData* NewData = nullptr) override;
+	virtual void OnDataPropertiesChanged(const URoomData* Data = nullptr) override;
 
 	bool HasValidSelection() const;
 	void ResetDragPoint();
-	void UpdateDataAsset() const;
+	void UpdateDataAsset(int32 BoxIndex) const;
 
 	void SetSelectedPoint(int32 Index);
 	void ResetSelectedPoint();
 
 private:
+	int32 GetBoxIndexFromPointIndex(int32 PointIndex) const { return PointIndex / FBoxPoints::NbPoints; }
+	int32 GetBoxPointIndex(int32 PointIndex) const { return PointIndex % FBoxPoints::NbPoints; }
+	int32 GetMaxIndex() const { return Boxes.Num() * FBoxPoints::NbPoints; }
+	FRoomPoint& GetSelectedPoint();
+	void UpdateBoxes(const URoomData* Data);
+
+private:
 	int32 SelectedPoint {-1};
-	TArray<FRoomPoint> Points;
+	TArray<FBoxPoints> Boxes;
 	FVector DragPoint;
 };


### PR DESCRIPTION
## 🔍 Description
Adds multiple boxes for the room bounds, allowing more room creation freedom to game designers.

## 📝 Type of Change
<!-- Check the appropriate boxes. You can replace [ ] with [x] -->
- [ ] Bug fix (`fixes` branch - patch version)
- [x] New feature (`minor` branch - minor version)
- [ ] Breaking change (`major` branch - major version)
- [ ] Documentation update

## 🔗 Related Issues
<!-- Link any related issues using #issue-number -->
<!-- Delete this section if not applicable -->

## ✅ Checklist
<!-- All the boxes must be checked -->
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] I have chosen the correct base branch (`fixes`, `minor`, or `major`)
- [x] I have rebased my feature branch onto the latest commit of the base branch
- [x] I have cleaned up my branch history (squashed/reorganized commits)
- [x] My commits are atomic (one logical change per commit)
- [x] All existing and new tests are passing
- [x] I understand that I must sign the Contributor License Agreement (CLA) before this PR can be merged

## 🔄 SemVer Impact
<!-- Describe how this change impacts semantic versioning -->
This is a **minor** change because:
<!-- Explain why this is a patch/minor/major change -->
New variables in the `RoomData` asset, deprecating old `FirstPoint` and `SecondPoint`, cascading into quite some changes in the generation logic and editor tools.

## 📋 Migration Notes
<!-- For major changes, provide migration instructions for users -->
<!-- Delete this section if not applicable -->
Deprecated variables are automatically converted into new variable on asset load, but for changes to be permanent, resave all your `RoomData` assets after updating the plugin.
